### PR TITLE
Updated a pair of header files to fix compilation on Ubuntu 14.04 LTS

### DIFF
--- a/environments/CanonicalGrid.h
+++ b/environments/CanonicalGrid.h
@@ -17,6 +17,7 @@
 #include "SearchEnvironment.h"
 #include "UnitSimulation.h"
 #include <cassert>
+#include <cstring>
 
 namespace CanonicalGrid {
 	

--- a/utils/GLUtil.h
+++ b/utils/GLUtil.h
@@ -27,6 +27,7 @@
 
 #include "FPUtil.h"
 #include <ostream>
+#include <cstring>
 
 #ifdef __APPLE__
 #include "TargetConditionals.h"


### PR DESCRIPTION
Just added #include <cstring> to a few of the header files to fix the compilation. The strlen function is not included by default in Ubuntu 14.04 LTS with GCC version 4.8.4.
