### PR TITLE
fix a bug where IDAStar sometimes returns sub-optimal solutions

### DIFF
--- a/generic/IDAStar.h
+++ b/generic/IDAStar.h
@@ -172,7 +172,7 @@ double IDAStar<state, action, verbose>::DoIteration(SearchEnvironment<state, act
 		double edgeCost = env->GCost(currState, neighbors[x]);
 		double childH = DoIteration(env, currState, neighbors[x], thePath, bound,
 																g+edgeCost, maxH - edgeCost);
-		if (env->GoalTest(thePath.back(), goal))
+		if (env->GoalTest(thePath.back(), goal) && g+edgeCost<=bound) //check that a solution that does not exceed the bound was found
 			return 0;
 		thePath.pop_back();
 		// pathmax

--- a/generic/IDAStar.h
+++ b/generic/IDAStar.h
@@ -172,7 +172,7 @@ double IDAStar<state, action, verbose>::DoIteration(SearchEnvironment<state, act
 		double edgeCost = env->GCost(currState, neighbors[x]);
 		double childH = DoIteration(env, currState, neighbors[x], thePath, bound,
 																g+edgeCost, maxH - edgeCost);
-		if (env->GoalTest(thePath.back(), goal) && g+edgeCost<=bound) //check that a solution that does not exceed the bound was found
+		if (env->GoalTest(thePath.back(), goal) && flesseq(g+edgeCost,bound)) //check that a solution that does not exceed the bound was found
 			return 0;
 		thePath.pop_back();
 		// pathmax


### PR DESCRIPTION
IDAStar first adds a neighboring node to the path, checks if this node is a goal and if so returns is as an optimal solution. However, IDAStar did not make sure that the solution cost is not larger than the current bound, which could lead to sub-optimal solutions; this fix address that issue by adding the missing condition. 