### PR TITLE
Fix compile warnings

### DIFF
--- a/abstraction/ClusterAbstraction.h
+++ b/abstraction/ClusterAbstraction.h
@@ -12,12 +12,12 @@
 #ifndef CLUSTERABSTRACTION_H
 #define CLUSTERABSTRACTION_H
 
-#include <vector>
-#include <ext/hash_map>
-
 #include "MapAbstraction.h"
 #include "Graph.h" 
 #include "Path.h"
+
+#include <unordered_map>
+#include <vector>
 
 typedef enum{HORIZONTAL,VERTICAL} Orientation;
 
@@ -39,7 +39,7 @@ namespace clusterUtil {
 		{ return (size_t)(e->getEdgeNum()); }
 	};
       
-  typedef __gnu_cxx::hash_map<edge*,path*,
+  typedef std::unordered_map<edge*,path*,
 															clusterUtil::EdgeHash, 
 															clusterUtil::EdgeEqual > PathLookupTable;
 }

--- a/abstractionalgorithms/AStar.h
+++ b/abstractionalgorithms/AStar.h
@@ -17,8 +17,9 @@
 #include "Path.h"
 #include "GraphAbstraction.h"
 #include "FPUtil.h"
-#include <ext/hash_map>
 #include "OpenClosedList.h"
+
+#include <unordered_map>
 
 namespace AStar3Util
 {
@@ -70,10 +71,10 @@ public:
 	typedef OpenClosedList<AStar3Util::SearchNode, AStar3Util::SearchNodeHash,
 		AStar3Util::SearchNodeEqual, AStar3Util::SearchNodeCompare> PQueue;
 	
-	typedef __gnu_cxx::hash_map<node*, AStar3Util::SearchNode,
+	typedef std::unordered_map<node*, AStar3Util::SearchNode,
 		AStar3Util::NodeHash, AStar3Util::NodeEqual > NodeLookupTable;
 	
-	typedef __gnu_cxx::hash_map<node*, bool,
+	typedef std::unordered_map<node*, bool,
 		AStar3Util::NodeHash, AStar3Util::NodeEqual > Corridor;
 }
 

--- a/abstractionalgorithms/CFOptimalRefinement.h
+++ b/abstractionalgorithms/CFOptimalRefinement.h
@@ -10,12 +10,13 @@
 #ifndef CFOPTIMALREFINEMENT_H
 #define CFOPTIMALREFINEMENT_H
 
-#include <ext/hash_map>
 #include "SearchAlgorithm.h"
 #include "OpenClosedList.h"
 #include "FPUtil.h"
 #include "Graph.h"
 #include "GraphAbstraction.h"
+
+#include <unordered_map>
 
 namespace CFOptimalRefinementConstants {
 
@@ -80,7 +81,7 @@ namespace CFOptimalRefinementConstants {
 typedef OpenClosedList<CFOptimalRefinementConstants::GNode, CFOptimalRefinementConstants::NodeHash,
 CFOptimalRefinementConstants::NodeEqual, CFOptimalRefinementConstants::NodeCompare> PQueue;
 
-typedef __gnu_cxx::hash_map<uint32_t, CFOptimalRefinementConstants::GNode> NodeLookupTable;
+typedef std::unordered_map<uint32_t, CFOptimalRefinementConstants::GNode> NodeLookupTable;
 
 // variables starting with "a" are in the abstraction
 // variables starting with "g" are in the defined search graph

--- a/abstractionalgorithms/IRAStar.cpp
+++ b/abstractionalgorithms/IRAStar.cpp
@@ -599,7 +599,7 @@ void IRAStar::OpenGLDraw() const
 void IRAStar::SetHValues( int f )
 {
 	NodeLookupTable::iterator ni ;
-	//typedef __gnu_cxx::hash_map<uint32_t, GNode> NodeLookupTable;
+	//typedef std::unordered_map<uint32_t, GNode> NodeLookupTable;
 	
 	for ( ni = closedList.begin(); ni != closedList.end(); ni++ )
 	{

--- a/abstractionalgorithms/IRAStar.h
+++ b/abstractionalgorithms/IRAStar.h
@@ -10,12 +10,13 @@
 #ifndef IRAStar_H
 #define IRAStar_H
 
-#include <ext/hash_map>
 #include "SearchAlgorithm.h"
 #include "OpenClosedList.h"
 #include "FPUtil.h"
 #include "Graph.h"
 #include "GraphAbstraction.h"
+
+#include <unordered_map>
 
 namespace IRAStarConstants {
 	
@@ -68,7 +69,7 @@ namespace IRAStarConstants {
 	typedef OpenClosedList<GNode, NodeHash,
 		NodeEqual, NodeCompare> PQueue;
 	
-	typedef __gnu_cxx::hash_map<uint32_t, GNode> NodeLookupTable;
+	typedef std::unordered_map<uint32_t, GNode> NodeLookupTable;
 }
 
 

--- a/abstractionalgorithms/IRDijkstra.h
+++ b/abstractionalgorithms/IRDijkstra.h
@@ -10,12 +10,13 @@
 #ifndef IRDijkstra_H
 #define IRDijkstra_H
 
-#include <ext/hash_map>
 #include "SearchAlgorithm.h"
 #include "OpenClosedList.h"
 #include "FPUtil.h"
 #include "Graph.h"
 #include "GraphAbstraction.h"
+
+#include <unordered_map>
 
 namespace IRDijkstraConstants {
 
@@ -58,7 +59,7 @@ namespace IRDijkstraConstants {
 	typedef OpenClosedList<GNode, NodeHash,
 		NodeEqual, NodeCompare> PQueue;
 	
-	typedef __gnu_cxx::hash_map<uint32_t, GNode> NodeLookupTable;
+	typedef std::unordered_map<uint32_t, GNode> NodeLookupTable;
 }
 
 

--- a/algorithms/AStarOpenClosed.h
+++ b/algorithms/AStarOpenClosed.h
@@ -13,10 +13,10 @@
 #define ASTAROPENCLOSED_H
 
 #include <cassert>
-#include <vector>
-#include <ext/hash_map>
-#include <stdint.h>
 #include <functional>
+#include <stdint.h>
+#include <unordered_map>
+#include <vector>
 
 struct AHash64 {
 	size_t operator()(const uint64_t &x) const
@@ -110,7 +110,7 @@ private:
 	std::vector<uint64_t> theHeap;
 	// storing the element id; looking up with...hash?
 	// TODO: replace this with C++11 data structures
-	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, AHash64> IndexTable;
+	typedef std::unordered_map<uint64_t, uint64_t, AHash64> IndexTable;
 	IndexTable table;
 	std::vector<dataStructure > elements;
 };

--- a/algorithms/BDIndexOpenClosed.h
+++ b/algorithms/BDIndexOpenClosed.h
@@ -7,7 +7,7 @@
 
 #include <cassert>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <stdint.h>
 #include <unordered_map>
 #include "AStarOpenClosed.h"

--- a/algorithms/BDOpenClosed.h
+++ b/algorithms/BDOpenClosed.h
@@ -7,7 +7,7 @@
 
 #include <cassert>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <stdint.h>
 #include <unordered_map>
 #include "AStarOpenClosed.h"

--- a/algorithms/BucketOpenClosed.h
+++ b/algorithms/BucketOpenClosed.h
@@ -48,7 +48,7 @@ private:
 	};
 	std::vector<qData> pQueue;
 	// storing the element id; looking up with...hash?
-	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, AHash64> IndexTable;
+	typedef std::unordered_map<uint64_t, uint64_t, AHash64> IndexTable;
 	IndexTable table;
 	std::vector<dataStructure > elements;
 };

--- a/algorithms/DVCBSOpenClosed.h
+++ b/algorithms/DVCBSOpenClosed.h
@@ -10,7 +10,7 @@
 
 #include <cassert>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <stdint.h>
 #include "AStarOpenClosed.h"
 #include <unordered_map>
@@ -83,7 +83,7 @@ private:
 	//std::vector<uint64_t> waitingQueue;
 	
 	// storing the element id; looking up with...hash?
-	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, AHash64> IndexTable;
+	typedef std::unordered_map<uint64_t, uint64_t, AHash64> IndexTable;
 	
 	IndexTable table;
 	//all the elements, open or closed

--- a/algorithms/GenericAStar.h
+++ b/algorithms/GenericAStar.h
@@ -23,10 +23,10 @@
 #endif
 
 #include "FPUtil.h"
-#include <ext/hash_map>
 #include "OpenClosedList.h"
 #include "OldSearchEnvironment.h" // for the SearchEnvironment class
 
+#include <unordered_map>
 
 namespace GenericAStarUtil
 {
@@ -66,9 +66,9 @@ public:
 	typedef OpenClosedList<GenericAStarUtil::SearchNode, GenericAStarUtil::SearchNodeHash,
 		GenericAStarUtil::SearchNodeEqual, GenericAStarUtil::SearchNodeCompare> PQueue;
 	
-	typedef __gnu_cxx::hash_map<uint32_t, GenericAStarUtil::SearchNode > NodeLookupTable;
+	typedef std::unordered_map<uint32_t, GenericAStarUtil::SearchNode > NodeLookupTable;
 	
-	typedef __gnu_cxx::hash_map<uint32_t, bool > Corridor;
+	typedef std::unordered_map<uint32_t, bool > Corridor;
 }
 
 

--- a/algorithms/GenericIDAStar.h
+++ b/algorithms/GenericIDAStar.h
@@ -11,10 +11,11 @@
 #ifndef GENERICIDASTAR_H
 #define GENERICIDASTAR_H
 
-#include <ext/hash_map>
 #include "OldSearchEnvironment.h" // for the SearchEnvironment class
 
-typedef __gnu_cxx::hash_map<uint32_t, double> NodeHashTable;
+#include <unordered_map>
+
+typedef std::unordered_map<uint32_t, double> NodeHashTable;
 
 class GenericIDAStar {
 public:

--- a/algorithms/OpenClosedList.h
+++ b/algorithms/OpenClosedList.h
@@ -14,9 +14,9 @@
 
 #include <cassert>
 #include <vector>
-#include <ext/hash_map>
 #include <stdio.h>
 #include <stdint.h>
+#include <unordered_map>
 
 /**
 * A simple Heap class.
@@ -45,7 +45,7 @@ private:
 	std::vector<OBJ> _elts;
 	void HeapifyUp(unsigned int index);
 	void HeapifyDown(unsigned int index);
-	typedef __gnu_cxx::hash_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
+	typedef std::unordered_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
 	IndexTable table;
 };
 
@@ -121,7 +121,7 @@ template<typename OBJ, class HashKey, class EqKey, class CmpKey>
 bool OpenClosedList<OBJ, HashKey, EqKey, CmpKey>::IsIn(const OBJ val) const
 {
 	EqKey eq;
-	//	typedef __gnu_cxx::hash_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
+	//	typedef std::unordered_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
 	typename IndexTable::const_iterator it;
 	it = table.find(val);
 	if (it != table.end())

--- a/algorithms/OpenListB.h
+++ b/algorithms/OpenListB.h
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <vector>
 #include <deque>
-#include <ext/hash_map>
+#include <unordered_map>
 
 /**
 * A simple & efficient Heap class.
@@ -48,7 +48,7 @@ private:
   std::vector<OBJ> _elts;
 	void HeapifyUp(unsigned int index);
   void HeapifyDown(unsigned int index);
-	typedef __gnu_cxx::hash_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
+	typedef std::unordered_map<OBJ, unsigned int, HashKey, EqKey > IndexTable;
 	IndexTable table;
 };
 

--- a/apps/airplane/Driver.cpp
+++ b/apps/airplane/Driver.cpp
@@ -302,7 +302,7 @@ void MyPathfindingKeyHandler(unsigned long , tKeyboardModifier , char)
 //	Directional2DEnvironment d(&m);
 //	//Directional2DEnvironment(Map *m, model envType = kVehicle, heuristicType heuristic = kExtendedPerimeterHeuristic);
 //	xySpeedHeading l1(50, 50), l2(50, 50);
-//	__gnu_cxx::hash_map<uint64_t, xySpeedHeading, Hash64 > stateTable;
+//	std::unordered_map<uint64_t, xySpeedHeading, Hash64 > stateTable;
 //	
 //	std::vector<xySpeedHeading> path;
 //	TemplateAStar<xySpeedHeading, deltaSpeedHeading, Directional2DEnvironment> alg;

--- a/apps/arm/RoboticArmTest.cpp
+++ b/apps/arm/RoboticArmTest.cpp
@@ -1088,7 +1088,7 @@ void WriteCache(int index, std::vector<armAngles> &values)
 	if (!f) assert(!"Couldn't open file!");
 	for (unsigned int x = 0; x < values.size(); x++)
 	{
-		for (unsigned int y = 0; y < values[x].GetNumArms(); y++)
+		for (int y = 0; y < values[x].GetNumArms(); y++)
 			fprintf(f, "%d ", values[x].GetAngle(y));
 		fprintf(f, "\n");
 	}

--- a/apps/bidirectional/MM0Rubik.cpp
+++ b/apps/bidirectional/MM0Rubik.cpp
@@ -317,7 +317,7 @@ void CheckSolution(std::unordered_map<openData, openList, openDataHash> currentO
 			size_t numRead;
 			do {
 				numRead = fread(buffer, sizeof(uint64_t), bufferSize, s.second.f);
-				for (int x = 0; x < numRead; x++)
+				for (size_t x = 0; x < numRead; x++)
 				{
 					if (states.find(buffer[x]) != states.end())
 					{
@@ -345,7 +345,7 @@ void ReadBucket(std::unordered_set<uint64_t> &states, openData d)
 	size_t numRead;
 	do {
 		numRead = fread(buffer, sizeof(uint64_t), bufferSize, open[d].f);
-		for (int x = 0; x < numRead; x++)
+		for (size_t x = 0; x < numRead; x++)
 			states.insert(buffer[x]);
 	} while (numRead == bufferSize);
 	fclose(open[d].f);
@@ -384,7 +384,7 @@ void RemoveDuplicates(std::unordered_set<uint64_t> &states, openData d)
 		size_t numRead;
 		do {
 			numRead = fread(buffer, sizeof(uint64_t), bufferSize, cd.f);
-			for (int x = 0; x < numRead; x++)
+			for (size_t x = 0; x < numRead; x++)
 			{
 				auto i = states.find(buffer[x]);
 				if (i != states.end())
@@ -494,7 +494,7 @@ void ExpandNextFile()
 	std::vector<std::thread *> threads;
 	for (int x = 0; x < numThreads; x++)
 		threads.push_back(new std::thread(ParallelExpandBucket, d, std::ref(states), x, numThreads));
-	for (int x = 0; x < threads.size(); x++)
+	for (size_t x = 0; x < threads.size(); x++)
 	{
 		threads[x]->join();
 		delete threads[x];

--- a/apps/bidirectional/MMRubik.cpp
+++ b/apps/bidirectional/MMRubik.cpp
@@ -431,7 +431,7 @@ void ReadBucket(bucketSet &states, openData d)
 	size_t numRead;
 	do {
 		numRead = fread(buffer, sizeof(diskState), bufferSize, open[d].f);
-		for (int x = 0; x < numRead; x++)
+		for (size_t x = 0; x < numRead; x++)
 			states.insert(buffer[x]);
 	} while (numRead == bufferSize);
 	fclose(open[d].f);
@@ -459,7 +459,7 @@ void RemoveDuplicates(bucketSet &states, openData d)
 		size_t numRead;
 		do {
 			numRead = fread(buffer, sizeof(diskState), bufferSize, cd.f);
-			for (int x = 0; x < numRead; x++)
+			for (size_t x = 0; x < numRead; x++)
 			{
 				auto i = states.find(buffer[x]);
 				if (i != states.end())
@@ -626,11 +626,11 @@ void ExpandNextFile()
 #endif
 	
 	// 3. expand all states in current bucket & write out successors
-	const int numThreads = std::thread::hardware_concurrency();
+	const auto numThreads = std::thread::hardware_concurrency();
 	std::vector<std::thread *> threads;
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 		threads.push_back(new std::thread(ParallelExpandBucket, d, std::ref(states), x, numThreads));
-	for (int x = 0; x < threads.size(); x++)
+	for (size_t x = 0; x < threads.size(); x++)
 	{
 		threads[x]->join();
 		delete threads[x];

--- a/apps/bidirectional/old/BDOpenClosed.h
+++ b/apps/bidirectional/old/BDOpenClosed.h
@@ -7,7 +7,7 @@
 
 #include <cassert>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <stdint.h>
 #include "AStarOpenClosed.h"
 
@@ -118,7 +118,7 @@ private:
 	//std::vector<uint64_t> waitingQueue;
 
 	// storing the element id; looking up with...hash?
-	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, AHash64> IndexTable;
+	typedef std::unordered_map<uint64_t, uint64_t, AHash64> IndexTable;
 	
 	IndexTable table;
 	//all the elements, open or closed

--- a/apps/directional/directional.cpp
+++ b/apps/directional/directional.cpp
@@ -462,7 +462,7 @@ void MyPathfindingKeyHandler(unsigned long , tKeyboardModifier , char)
 //	Directional2DEnvironment d(&m);
 //	//Directional2DEnvironment(Map *m, model envType = kVehicle, heuristicType heuristic = kExtendedPerimeterHeuristic);
 //	xySpeedHeading l1(50, 50), l2(50, 50);
-//	__gnu_cxx::hash_map<uint64_t, xySpeedHeading, Hash64 > stateTable;
+//	std::unordered_map<uint64_t, xySpeedHeading, Hash64 > stateTable;
 //	
 //	std::vector<xySpeedHeading> path;
 //	TemplateAStar<xySpeedHeading, deltaSpeedHeading, Directional2DEnvironment> alg;

--- a/apps/emotion/Sample.cpp
+++ b/apps/emotion/Sample.cpp
@@ -305,7 +305,7 @@ void MyPathfindingKeyHandler(unsigned long windowID, tKeyboardModifier , char)
 void ExportGraph(Map *m, Map2DHeading *env)
 {
 	// export map as graph
-	typedef __gnu_cxx::hash_map<uint64_t, int, Hash64> HT;
+	typedef std::unordered_map<uint64_t, int, Hash64> HT;
 
 	HT table;
 	Graph *g = new Graph();
@@ -388,7 +388,7 @@ void ExportGraph(Map *m)
 	Directional2DEnvironment *env = new Directional2DEnvironment(m, kVehicle, kOctileHeuristic);
 
 	// export map as graph
-	typedef __gnu_cxx::hash_map<uint64_t, int, Hash64> HT;
+	typedef std::unordered_map<uint64_t, int, Hash64> HT;
 	
 	HT table;
 	Graph *g = new Graph();
@@ -622,5 +622,3 @@ bool MyClickHandler(unsigned long windowID, int, int, point3d loc, tButtonType b
 	}
 	return false;
 }
-
-

--- a/apps/fling/Driver.cpp
+++ b/apps/fling/Driver.cpp
@@ -439,7 +439,7 @@ int MyCLHandler(char *argument[], int maxNumArgs)
 		}
 
 		GetSolveActions(b, stateActs);
-		for (int x = 0; x < stateActs.size(); x++)
+		for (size_t x = 0; x < stateActs.size(); x++)
 		{
 			std::cout << stateActs[stateActs.size()-1-x] << " ";
 		}
@@ -457,7 +457,7 @@ int MyCLHandler(char *argument[], int maxNumArgs)
 		}
 		std::cout << "\n";
 		f.GetStateFromHash(which, b);
-		for (int x = 0; x < stateActs.size(); x++)
+		for (size_t x = 0; x < stateActs.size(); x++)
 		{
 			std::cout << stateActs[stateActs.size()-1-x] << "\n";
 			f.ApplyAction(b, stateActs[stateActs.size()-1-x]);
@@ -485,7 +485,7 @@ int MyCLHandler(char *argument[], int maxNumArgs)
 		
 		GetSolveActions(b, stateActs);
 		std::cout << b << "\n";
-		for (int x = 0; x < stateActs.size(); x++)
+		for (size_t x = 0; x < stateActs.size(); x++)
 		{
 			std::cout << stateActs[stateActs.size()-1-x] << " ";
 		}
@@ -973,7 +973,7 @@ void ExtractUniqueStates(int depth)
 		{
 			f.unrankPlayer(t, depth, board);
 			bool ok = false;
-			for (int x = 0; x < board.width; x++)
+			for (unsigned int x = 0; x < board.width; x++)
 			{
 				if (board.HasPiece(x, 0))
 				{
@@ -984,7 +984,7 @@ void ExtractUniqueStates(int depth)
 			if (ok == false)
 				continue;
 			ok = false;
-			for (int y = 0; y < board.height; y++)
+			for (unsigned int y = 0; y < board.height; y++)
 			{
 				if (board.HasPiece(0, y))
 				{
@@ -1127,7 +1127,7 @@ bool IsSolvable(FlingBoard &theState)
 
 uint64_t RecursiveBFS(FlingBoard from, std::vector<FlingBoard> &thePath, Fling *env)
 {
-	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, Hash64> BFSClosedList;
+	typedef std::unordered_map<uint64_t, uint64_t, Hash64> BFSClosedList;
 	std::deque<FlingBoard> mOpen;
 	std::deque<int> depth;
 	BFSClosedList mClosed; // store parent id!
@@ -1628,9 +1628,9 @@ void RemoveDups(std::vector<uint64_t> &values)
 {
 	std::vector<std::vector<FlingMove> > stateActs;
 
-	for (int x = 0; x < values.size(); x++)
+	for (size_t x = 0; x < values.size(); x++)
 	{
-		for (int y = x+1; y < values.size(); y++)
+		for (size_t y = x+1; y < values.size(); y++)
 		{
 			while (y < values.size() && values[x] == values[y])
 				//if (BitCount(values[x]^values[y]) <= 4)
@@ -1640,7 +1640,7 @@ void RemoveDups(std::vector<uint64_t> &values)
 		}
 	}
 	stateActs.resize(values.size());
-	for (int x = 0; x < values.size(); x++)
+	for (size_t x = 0; x < values.size(); x++)
 	{
 		f.GetStateFromHash(values[x], b);
 		GetSolveActions(b, stateActs[x]);
@@ -1649,9 +1649,9 @@ void RemoveDups(std::vector<uint64_t> &values)
 		printf("(%d)\n", x);
 	}
 	// find exact correlation between moves
-	for (int x = 0; x < values.size(); x++)
+	for (size_t x = 0; x < values.size(); x++)
 	{
-		for (int y = x+1; y < values.size(); y++)
+		for (size_t y = x+1; y < values.size(); y++)
 		{
 			f.GetStateFromHash(values[x], b);
 			std::cout << x << "\n" << b << "\n\n";
@@ -1661,15 +1661,15 @@ void RemoveDups(std::vector<uint64_t> &values)
 			int acts[4] = {-1, -1, -1, -1};
 			bool match = true;
 			// skip the first move, because the last one could go right OR left / down OR up
-			for (int t = 0; t < stateActs[x].size(); t++)
+			for (size_t t = 0; t < stateActs[x].size(); t++)
 				std::cout << stateActs[x][t].dir << " ";
 			printf("(%d)\n", x);
-			for (int t = 0; t < stateActs[y].size(); t++)
+			for (size_t t = 0; t < stateActs[y].size(); t++)
 				std::cout << stateActs[y][t].dir << " ";
 			printf("(%d)\n", y);
 
 			// 1. need constant mapping between actions
-			for (int t = 1; t < stateActs[x].size(); t++)
+			for (size_t t = 1; t < stateActs[x].size(); t++)
 			{
 				std::cout << "Comparing [" << t << "] " << stateActs[x][t].dir << " to " << stateActs[y][t].dir << "\n";
 				if (acts[stateActs[x][t].dir] == -1)
@@ -1712,7 +1712,7 @@ void RemoveDups(std::vector<uint64_t> &values)
 				// 2. also need constant relative flipping
 				int diff = (abs(stateActs[x][1].dir - stateActs[y][1].dir)+2)%2;
 				printf("Looking for offset of %d\n", diff);
-				for (int t = 1; t < stateActs[x].size(); t++)
+				for (size_t t = 1; t < stateActs[x].size(); t++)
 				{
 					printf("Offset between %d and %d is %d\n", stateActs[x][t].dir, stateActs[y][t].dir,
 						   (2+abs(stateActs[x][t].dir - stateActs[y][t].dir))%2);
@@ -1811,7 +1811,7 @@ void RemoveDups(std::vector<uint64_t> &values)
 		}
 	}
 	printf("Final states:\n");
-	for (int x = 0; x < values.size(); x++)
+	for (size_t x = 0; x < values.size(); x++)
 	{
 		f.GetStateFromHash(values[x], b);
 		std::cout << x << "\n" << b << "\n\n";
@@ -1931,17 +1931,17 @@ void ThreadedEndLocAnalyze(int level, uint64_t start, uint64_t end, std::mutex *
 void AnalyzeEndLocs(int level)
 {
 	uint64_t maxVal = f.getMaxSinglePlayerRank(56, level);
-	int numThreads = std::thread::hardware_concurrency();
+	const auto numThreads = std::thread::hardware_concurrency();
 	std::cout << "Running with " << numThreads << " threads\n";
 	
 	uint64_t perThread = maxVal/numThreads;
 	std::vector<std::thread*> threads;
 	std::mutex lock;
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 	{
 		threads.push_back(new std::thread(ThreadedEndLocAnalyze, level, x*perThread, (x+1)*perThread, &lock));
 	}
-	for (int x = 0; x < threads.size(); x++)
+	for (size_t x = 0; x < threads.size(); x++)
 	{
 		threads[x]->join();
 		delete threads[x];
@@ -1990,17 +1990,17 @@ void ThreadedRockAnalyze(int level, uint64_t start, uint64_t end, std::mutex *lo
 void AnalyzeRocks(int level)
 {
 	uint64_t maxVal = f.getMaxSinglePlayerRank(56, level);
-	int numThreads = std::thread::hardware_concurrency();
+	const auto numThreads = std::thread::hardware_concurrency();
 	std::cout << "Running with " << numThreads << " threads\n";
 	
 	uint64_t perThread = maxVal/numThreads;
 	std::vector<std::thread*> threads;
 	std::mutex lock;
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 	{
 		threads.push_back(new std::thread(ThreadedRockAnalyze, level, x*perThread, (x+1)*perThread, &lock));
 	}
-	for (int x = 0; x < threads.size(); x++)
+	for (size_t x = 0; x < threads.size(); x++)
 	{
 		threads[x]->join();
 		delete threads[x];

--- a/apps/localsensingsearch/CanonicalRTAStar.h
+++ b/apps/localsensingsearch/CanonicalRTAStar.h
@@ -16,7 +16,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "Map2DEnvironment.h"
 #include "CanonicalGrid.h"
 #include <unordered_map>

--- a/apps/localsensingsearch/FLRTAStar2.h
+++ b/apps/localsensingsearch/FLRTAStar2.h
@@ -13,7 +13,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include <queue>
@@ -107,8 +107,8 @@ namespace FLRTA2 {
 		void OpenGLDraw(const environment *env) const;
 	private:
 		typedef std::priority_queue<borderData<state>,std::vector<borderData<state> >,compareBorderData<state> > pQueue;
-		typedef __gnu_cxx::hash_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
-		typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+		typedef std::unordered_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
+		typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 		
 
 		bool ExpandLSS(environment *env, const state &from, const state &to, std::vector<state> &thePath);

--- a/apps/localsensingsearch/GridLSSLRTAStar.h
+++ b/apps/localsensingsearch/GridLSSLRTAStar.h
@@ -13,7 +13,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include <queue>
@@ -113,8 +113,8 @@ namespace GridLRTA {
 		void OpenGLDraw(const MapEnvironment *env) const;
 	private:
 		typedef std::priority_queue<borderData,std::vector<borderData >,compareBorderData > pQueue;
-		typedef __gnu_cxx::hash_map<uint64_t, lssLearnedData, Hash64 > LearnedHeuristic;
-		typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+		typedef std::unordered_map<uint64_t, lssLearnedData, Hash64 > LearnedHeuristic;
+		typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 		
 		
 		void ExpandLSS(MapEnvironment *env, const xyLoc &from, const xyLoc &to, std::vector<xyLoc> &thePath);

--- a/apps/localsensingsearch/LocalSensingUnit.h
+++ b/apps/localsensingsearch/LocalSensingUnit.h
@@ -8,7 +8,7 @@
  */
 
 #include "Unit.h"
-#include <ext/hash_map>
+#include <unordered_map>
 
 template <class state, class action>
 struct stateInfo {
@@ -53,7 +53,7 @@ public:
 	void LogFinalStats(StatCollection *) {}
 private:
 	
-	typedef __gnu_cxx::hash_map<uint64_t, stateInfo<state, action>, Hash64 > LSStateStorage;
+	typedef std::unordered_map<uint64_t, stateInfo<state, action>, Hash64 > LSStateStorage;
 	LSStateStorage hashTable;
 	
 	bool init;

--- a/apps/localsensingsearch/RIBS.h
+++ b/apps/localsensingsearch/RIBS.h
@@ -9,7 +9,7 @@
 
 
 #include "Unit.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include <math.h>
 
 namespace LocalSensing {
@@ -91,7 +91,7 @@ namespace LocalSensing {
 		void RemoveChildrenPointers(environment *e, state &currentLoc);
 		bool AddOptimalParent(stateInfo<state, action> &info, action a);
 
-		typedef __gnu_cxx::hash_map<uint64_t, stateInfo<state, action>, Hash64 > LSStateStorage;
+		typedef std::unordered_map<uint64_t, stateInfo<state, action>, Hash64 > LSStateStorage;
 		LSStateStorage hashTable;
 		
 		char name[255];

--- a/apps/mapUtils/Sample.cpp
+++ b/apps/mapUtils/Sample.cpp
@@ -478,11 +478,11 @@ void ThreadedGetPathLengthInRange(GraphEnvironment *ge, std::vector<graphState> 
 								  std::vector<double> &finalCost, double minLen, double maxLen, int numNeeded)
 {
 	std::vector<std::thread *> threads;
-	for (int x = 0; x < std::thread::hardware_concurrency(); x++)
+	for (size_t x = 0; x < std::thread::hardware_concurrency(); x++)
 	{
 		threads.push_back(new std::thread(GetPathLengthInRange, ge, minLen, maxLen, numNeeded));
 	}
-	for (int x = 0; x < threads.size(); x++)
+	for (size_t x = 0; x < threads.size(); x++)
 	{
 		threads[x]->join();
 	}
@@ -529,9 +529,9 @@ void buildProblemSet(const char *output = 0)
 	GraphEnvironment *ge = new GraphEnvironment(&map, g, &gdh);
 	ge->SetDirected(true);
 	
-	int numThreads = std::thread::hardware_concurrency();
+	const auto numThreads = std::thread::hardware_concurrency();
 	std::vector<std::thread *> threads;
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 	{
 		threads.push_back(new std::thread(PathfindingThread, ge));
 	}
@@ -544,7 +544,7 @@ void buildProblemSet(const char *output = 0)
 	//double len = EstimateLongPath(&map);
 	printf("First pass: 100%% random\n");
 	int totalTries = g->GetNumNodes()/10;//9*g->GetNumNodes()/10;
-	for (unsigned int x = 0; x < totalTries; x++)
+	for (int x = 0; x < totalTries; x++)
 	{
 		if (0==x%100)
 		{ printf("\r%d of %d", x, totalTries); fflush(stdout); }
@@ -572,7 +572,7 @@ void buildProblemSet(const char *output = 0)
 		gs2 = g1->GetNum();
 		workQueue.WaitAdd({gs1, gs2});
 	}
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 	{
 		workQueue.WaitAdd({0, 0});
 	}
@@ -608,14 +608,14 @@ void buildProblemSet(const char *output = 0)
 	}
 	printf("\nDone receiving from threads\n");
 	
-	for (int x = 0; x < numThreads; x++)
+	for (size_t x = 0; x < numThreads; x++)
 	{
 		threads[x]->join();
 		delete threads[x];
 	}
 	threads.resize(0);
 	
-	for (int x = 0; x < experiments.size(); x++)
+	for (size_t x = 0; x < experiments.size(); x++)
 	{
 		while (experiments[x].size() != 10)
 		{
@@ -703,7 +703,7 @@ void buildRandomSet(const char *output = 0)
 	if (points.size() > 2000)
 		points.resize(2000);
 	astar.SetStopAfterGoal(true);
-	for (int x = 0; x < points.size(); x+= 2)
+	for (size_t x = 0; x < points.size(); x+= 2)
 	{
 		astar.GetPath(&me, points[x], points[x+1], path);
 		//	Experiment(int sx,int sy,int gx,int gy,int b, double d, string m)
@@ -1373,7 +1373,7 @@ void MySubgoalHandler(unsigned long windowID, tKeyboardModifier, char key)
 //	std::vector<std::pair<xyLoc, xyLoc>> subgoalEdges;
 	Map *map = unitSims[windowID]->GetEnvironment()->GetMap();
 	world.resize(map->GetMapWidth());
-	for (int x = 0; x < world.size(); x++)
+	for (size_t x = 0; x < world.size(); x++)
 	{
 		world[x].resize(map->GetMapHeight());
 		for (int y = 0; y < map->GetMapHeight(); y++)
@@ -2043,4 +2043,3 @@ void testHeuristic(char *problems)
 	
 	exit(0);
 }
-

--- a/apps/rubik/Driver.cpp
+++ b/apps/rubik/Driver.cpp
@@ -288,7 +288,7 @@ int MyCLHandler(char *argument[], int maxNumArgs)
 		
 		if (strcmp(argument[1], "apply") == 0)
 		{
-			for (int x = 0; x < acts.size(); x++)
+			for (size_t x = 0; x < acts.size(); x++)
 			{
 				animateActions.push_back(acts[x]);
 			}

--- a/apps/snakebird/Driver.cpp
+++ b/apps/snakebird/Driver.cpp
@@ -564,7 +564,7 @@ static void DrawEditorViewport(unsigned long windowID)
 //	editor.DrawLabel(d, kColumn1, 1, "Edit Map");
 //	editor.DrawLabel(d, kColumn2, 1, "EPCG AI Analysis");
 
-	for (int t = 0; t < editorItems.size(); t++)
+	for (size_t t = 0; t < editorItems.size(); t++)
 	{
 		if (kSelectedEditorItem == t)
 		{
@@ -1467,7 +1467,7 @@ bool MyClickHandler(unsigned long windowID, int viewport, int, int, point3d p, t
 		gMouseEditorY = y;
 		if (e == kMouseDown)
 		{
-			for (int t = 0; t < editorItems.size(); t++)
+			for (size_t t = 0; t < editorItems.size(); t++)
 			{
 				if (gMouseEditorY == editorItems[t].y &&
 					gMouseEditorX >= editorItems[t].x &&

--- a/build/gmake/Makefile.com.inc
+++ b/build/gmake/Makefile.com.inc
@@ -6,12 +6,12 @@
 #-----------------------------------------------------------------------------
 
 CXX = g++ # clang++
-COMMON_CXXFLAGS += -Wall -std=c++11 # -stdlib=libc++
+COMMON_CXXFLAGS += -Wall -std=c++11 -Wno-unused-function # -stdlib=libc++
 
 #COMMON_CXXFLAGS += -ansi -pedantic
 
 CC = gcc
-COMMON_CFLAGS += -Wall 
+COMMON_CFLAGS += -Wall -Wno-unused-function
 
 LN = $(CXX)
 #COMMON_LNFLAGS += -stdlib=libc++

--- a/demos/astar/Driver.cpp
+++ b/demos/astar/Driver.cpp
@@ -169,7 +169,7 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 		if (path.size() > 0)
 		{
 			ge->SetColor(0, 1, 0);
-			for (int x = 1; x < path.size(); x++)
+			for (size_t x = 1; x < path.size(); x++)
 			{
 				ge->DrawLine(display, path[x-1], path[x], 4);
 			}
@@ -518,7 +518,7 @@ void ShowSearchInfo()
 
 	std::vector<std::string> open, closed;
 	
-	for (int x = 0; x < astar.GetNumOpenItems(); x++)
+	for (size_t x = 0; x < astar.GetNumOpenItems(); x++)
 	{
 		auto item = astar.GetOpenItem(x);
 		s = g->GetNode(item.data)->GetName();

--- a/demos/dijkstra/Driver.cpp
+++ b/demos/dijkstra/Driver.cpp
@@ -146,7 +146,7 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 		if (path.size() > 0)
 		{
 			ge->SetColor(0, 0.5, 0);
-			for (int x = 1; x < path.size(); x++)
+			for (size_t x = 1; x < path.size(); x++)
 			{
 				ge->DrawLine(display, path[x-1], path[x], 6);
 			}

--- a/demos/idastar/Driver.cpp
+++ b/demos/idastar/Driver.cpp
@@ -407,7 +407,7 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 		{
 			//printf("Drawing edge on solution path\n");
 			ge->SetColor(0, 1, 0);
-			for (int x = 1; x < path.size(); x++)
+			for (size_t x = 1; x < path.size(); x++)
 			{
 				ge->DrawLine(display, path[x-1], path[x], 10);
 				//ge->GLDrawLine(path[x-1], path[x]);
@@ -1042,7 +1042,7 @@ void BuildGraphFromPuzzle()
 			{
 //				printf("%d at the average of ", n->GetNum());
 				double avg = 0;
-				for (int y = 0; y < allChildren.size(); y++)
+				for (size_t y = 0; y < allChildren.size(); y++)
 				{
 					avg += g->GetNode(allChildren[y])->GetLabelF(GraphSearchConstants::kXCoordinate);
 //					printf("%d ", allChildren[y]);
@@ -1183,4 +1183,3 @@ bool MyClickHandler(unsigned long , int windowX, int windowY, point3d loc, tButt
 	}
 	return false;
 }
-

--- a/deprecated/coprobber/DSCover.h
+++ b/deprecated/coprobber/DSCover.h
@@ -5,7 +5,7 @@
 //#include <utility>
 #include <queue>
 #include <ext/hash_set>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MultiAgentEnvironment.h"
 #include "GraphEnvironment.h"
 #include "Map2DEnvironment.h"

--- a/deprecated/coprobber/DSDijkstra.h
+++ b/deprecated/coprobber/DSDijkstra.h
@@ -82,7 +82,7 @@ class DSDijkstra {
 	};
 
 	// closed lists
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash> ClosedList;
+	typedef std::unordered_map<CRState, double, CRStateHash> ClosedList;
 	ClosedList min_cost, max_cost;
 
 	// TODO: Make this stable, this will only work with edge costs all set to 1

--- a/deprecated/coprobber/DSIDFPN.h
+++ b/deprecated/coprobber/DSIDFPN.h
@@ -1,6 +1,6 @@
 #include <vector>
 #include <map>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MyHash.h" // for uintplus
 #include "MultiAgentEnvironment.h"
 #include "DSCREnvironment.h"
@@ -61,7 +61,7 @@ class DSIDFPN {
 	};
 
 	// bound cache
-	typedef __gnu_cxx::hash_map<unsigned int, double> BoundCache;
+	typedef std::unordered_map<unsigned int, double> BoundCache;
 	// lower and upper bound cache
 	BoundCache min_lcache, max_lcache, min_ucache, max_ucache;
 
@@ -70,7 +70,7 @@ class DSIDFPN {
 		double value;
 		unsigned int pn, dn;
 	};
-	typedef __gnu_cxx::hash_map<unsigned int, TTEntry> OneLevelTT; // position => (dis)proof number bounds
+	typedef std::unordered_map<unsigned int, TTEntry> OneLevelTT; // position => (dis)proof number bounds
 	typedef std::map<double, OneLevelTT > TT; // Transposition Table with caching w.r.t gcost
 	// transposition tables
 	TT min_ttable, max_ttable;

--- a/deprecated/coprobber/DSRMAStar.h
+++ b/deprecated/coprobber/DSRMAStar.h
@@ -1,6 +1,6 @@
 #include <vector>
 #include <queue>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MultiAgentEnvironment.h"
 #include "DSCREnvironment.h"
 #include "GraphEnvironment.h"
@@ -70,7 +70,7 @@ class DSRMAStar {
 		}
 	};
 
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash> MyClosedList;
+	typedef std::unordered_map<CRState, double, CRStateHash> MyClosedList;
 	// state => value
 //	std::vector<double> min_cost, max_cost;
 	MyClosedList min_cost, max_cost;

--- a/deprecated/coprobber/DSTPDijkstra.h
+++ b/deprecated/coprobber/DSTPDijkstra.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <queue>
 #include <ext/hash_set>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MultiAgentEnvironment.h"
 #include "GraphEnvironment.h"
 #include "Map2DEnvironment.h"
@@ -88,7 +88,7 @@ class DSTPDijkstra: public DSRobberAlgorithm<state,action> {
 
 	typedef std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueEntryCompare> MyPriorityQueue;
 	typedef __gnu_cxx::hash_set<state, MyStateHash> CopClosedList;
-	typedef __gnu_cxx::hash_map<state, RobberClosedListEntry, MyStateHash> RobberClosedList;
+	typedef std::unordered_map<state, RobberClosedListEntry, MyStateHash> RobberClosedList;
 
 	MyPriorityQueue robber_queue, cop_queue;
 	CopClosedList cop_closed;

--- a/deprecated/coprobber/IPNTTables.h
+++ b/deprecated/coprobber/IPNTTables.h
@@ -40,7 +40,7 @@ class IPNTTables {
 			return ( c1 == c2 );
 		}
 	};
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
+	typedef std::unordered_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
 
 
 	// transposition tables

--- a/deprecated/coprobber/IPNTTables_optimized.h
+++ b/deprecated/coprobber/IPNTTables_optimized.h
@@ -42,7 +42,7 @@ class IPNTTables {
 			return ( c1 == c2 );
 		}
 	};
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
+	typedef std::unordered_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
 
 	// transposition tables
 	class TPEntry;
@@ -53,7 +53,7 @@ class IPNTTables {
 		bool operator() ( const TPEntry* p1, const TPEntry* p2 ) const { return (p1==p2); }
 	};
 	typedef __gnu_cxx::hash_set<TPEntry*, TPEntryPointerHash, TPEntryPointerEqual> Transpositions;
-	typedef __gnu_cxx::hash_map<CRState, Transpositions, CRStateHash, CRStateEqual> TTable;
+	typedef std::unordered_map<CRState, Transpositions, CRStateHash, CRStateEqual> TTable;
 
 
 	// the game tree nodes

--- a/deprecated/coprobber/MinimaxAStar.h
+++ b/deprecated/coprobber/MinimaxAStar.h
@@ -1,6 +1,6 @@
 #include <vector>
 #include <queue>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "GraphEnvironment.h"
 #include "CopRobberGame.h"
 #include "MyHash.h"
@@ -47,7 +47,7 @@ class MinimaxAStarMulti {
 	};
 
 	typedef std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueEntryCompare> MyPriorityQueue;
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash> MyClosedList;
+	typedef std::unordered_map<CRState, double, CRStateHash> MyClosedList;
 
 	// constructor
 	MinimaxAStarMulti( GraphEnvironment *_env, unsigned int _number_of_cops, bool _canPass );

--- a/deprecated/coprobber/MinimaxAStar_optimized.h
+++ b/deprecated/coprobber/MinimaxAStar_optimized.h
@@ -1,6 +1,6 @@
 #include <vector>
 #include <queue>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MyHash.h"
 #include "GraphEnvironment.h"
 #include "Map2DEnvironment.h"
@@ -51,7 +51,7 @@ class MinimaxAStar {
 	};
 
 	typedef std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueEntryCompare> MyPriorityQueue;
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash> MyClosedList;
+	typedef std::unordered_map<CRState, double, CRStateHash> MyClosedList;
 
 	// constructor
 	// for usage with state=graphState, action=graphMove, environment=GraphEnvironment

--- a/deprecated/coprobber/TIDAStar_optimized.h
+++ b/deprecated/coprobber/TIDAStar_optimized.h
@@ -4,7 +4,7 @@
 #include "Map2DEnvironment.h"
 #include "MyHash.h"
 #include <ext/hash_set>
-#include <ext/hash_map>
+#include <unordered_map>
 
 #ifndef TIDASTAR_H
 #define TIDASTAR_H
@@ -38,7 +38,7 @@ class TIDAStar {
 		}
 	};
 //	typedef __gnu_cxx::hash_set<CRState, CRStateHash, CRStateEqual> SearchCache;
-	typedef __gnu_cxx::hash_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
+	typedef std::unordered_map<CRState, double, CRStateHash, CRStateEqual> BoundCache;
 
 
 	// constructor

--- a/deprecated/coprobber/TwoCopsRMAStar.h
+++ b/deprecated/coprobber/TwoCopsRMAStar.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include <set>
 #include <queue>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "GraphEnvironment.h"
 #include "OpenClosedList.h"
 
@@ -102,7 +102,7 @@ class TwoCopsRMAStar {
 	MyPriorityQueue queue;
 
 	// closed lists
-	typedef __gnu_cxx::hash_map<Position,unsigned int> MyClosedList;
+	typedef std::unordered_map<Position,unsigned int> MyClosedList;
 	MyClosedList min_cost, max_cost;
 
 	void clear_cache();

--- a/deprecated/coprobber/TwoCopsTIDAStar.h
+++ b/deprecated/coprobber/TwoCopsTIDAStar.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include <set>
 #include <ext/hash_set>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "GraphEnvironment.h"
 
 #ifndef TWOCOPSTIDASTAR_H
@@ -58,7 +58,7 @@ class TwoCopsTIDAStar {
 
 	void clear_bounds_cache();
 
-	typedef __gnu_cxx::hash_map<Position, unsigned int> BoundCache;
+	typedef std::unordered_map<Position, unsigned int> BoundCache;
 	// lower bound cache
 	BoundCache min_lcache, max_lcache;
 	// upper bound cache

--- a/deprecated/coprobber/TwoPlayerDijkstra.h
+++ b/deprecated/coprobber/TwoPlayerDijkstra.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include <queue>
 #include <ext/hash_set>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "MultiAgentEnvironment.h"
 #include "GraphEnvironment.h"
 #include "Map2DEnvironment.h"
@@ -42,7 +42,7 @@ class TwoPlayerDijkstra {
 
 	typedef std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueEntryCompare> MyPriorityQueue;
 	typedef __gnu_cxx::hash_set<state, MyStateHash> CopClosedList;
-	typedef __gnu_cxx::hash_map<state, unsigned int, MyStateHash> RobberClosedList;
+	typedef std::unordered_map<state, unsigned int, MyStateHash> RobberClosedList;
 
 	// constructor
 	TwoPlayerDijkstra( environment *_env, bool _canPass ):

--- a/deprecated/dynamicsearch/GeneralBeamSearch.h
+++ b/deprecated/dynamicsearch/GeneralBeamSearch.h
@@ -3,7 +3,7 @@
 #include "StatCollection.h"
 #include "GenericStepAlgorithm.h"
 #include <algorithm>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <iostream>
 #include "BeamNode.h"
 #include "StringUtils.h"
@@ -123,9 +123,9 @@ public:
 	bool Node_Stored_In_Beams(state &s, uint64_t hash_value);
 	bool Node_Stored_In_Layer(state &s, uint64_t hash_value, std::vector<BeamNode<state> > &layer);
 
-	void Add_To_Beam_Hash(BeamNode<state> &node, beam_position &position, __gnu_cxx::hash_map<uint64_t, std::vector<beam_position>, Hash64> &node_hash);
+	void Add_To_Beam_Hash(BeamNode<state> &node, beam_position &position, std::unordered_map<uint64_t, std::vector<beam_position>, Hash64> &node_hash);
 
-	void Add_To_Layer_Hash(BeamNode<state> &node, unsigned position, __gnu_cxx::hash_map<uint64_t, std::vector<unsigned>, Hash64> &node_hash);
+	void Add_To_Layer_Hash(BeamNode<state> &node, unsigned position, std::unordered_map<uint64_t, std::vector<unsigned>, Hash64> &node_hash);
 
 	bool debug;
 
@@ -165,8 +165,8 @@ protected:
 
 	std::vector<std::vector <BeamNode<state> > > beams; // beam construct
 
-	__gnu_cxx::hash_map<uint64_t, std::vector<unsigned>, Hash64> nodes_in_current_layer; // nodes in the current layer constructing
-	__gnu_cxx::hash_map<uint64_t, std::vector<beam_position>, Hash64> nodes_in_beam; // nodes in beams not in current layer
+	std::unordered_map<uint64_t, std::vector<unsigned>, Hash64> nodes_in_current_layer; // nodes in the current layer constructing
+	std::unordered_map<uint64_t, std::vector<beam_position>, Hash64> nodes_in_beam; // nodes in beams not in current layer
 
 	environment *my_env;
 	state goal;
@@ -707,7 +707,7 @@ Adds a node to a hash. Assumes that this node is not already in the hash functio
 even if the hash value does exist there.
 **/
 template <class state, class action, class environment>
-void GeneralBeamSearch<state, action, environment>::Add_To_Beam_Hash(BeamNode<state> &node, beam_position &position, __gnu_cxx::hash_map<uint64_t, std::vector<beam_position>, Hash64> &node_hash) {
+void GeneralBeamSearch<state, action, environment>::Add_To_Beam_Hash(BeamNode<state> &node, beam_position &position, std::unordered_map<uint64_t, std::vector<beam_position>, Hash64> &node_hash) {
 
 	assert(prune_dups);
 	if(full_check && node_hash.find(node.my_key) != node_hash.end()) {
@@ -724,7 +724,7 @@ void GeneralBeamSearch<state, action, environment>::Add_To_Beam_Hash(BeamNode<st
 Adds a node to a hash. If full_check is set to true
 **/
 template <class state, class action, class environment>
-void GeneralBeamSearch<state, action, environment>::Add_To_Layer_Hash(BeamNode<state> &node, unsigned position, __gnu_cxx::hash_map<uint64_t, std::vector<unsigned>, Hash64> &node_hash) {
+void GeneralBeamSearch<state, action, environment>::Add_To_Layer_Hash(BeamNode<state> &node, unsigned position, std::unordered_map<uint64_t, std::vector<unsigned>, Hash64> &node_hash) {
 
 	assert(prune_dups);
 	if(full_check && node_hash.find(node.my_key) != node_hash.end()) {

--- a/deprecated/lv.pathfinding/benchmarkfull.cpp
+++ b/deprecated/lv.pathfinding/benchmarkfull.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <vector>
 #include <string>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <time.h>
 #include <math.h>
 #include <sys/time.h>
@@ -631,4 +631,3 @@ int main(int argc, char* argv[])
    y-axis: time
    each alg has 1 line
 */
-

--- a/deprecated/measure_inconsistency/measures.cpp
+++ b/deprecated/measure_inconsistency/measures.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 #include <vector>
 #include <time.h>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <math.h>
 #include "FPUtil.h"
 #include "UnitSimulation.h"

--- a/deprecated/sfbds/astar.h
+++ b/deprecated/sfbds/astar.h
@@ -133,7 +133,7 @@ protected:
 			return regular_state_hash<state>( s );
 		};
 	};
-	typedef __gnu_cxx::hash_map<state, double, RegularHash> DistanceList;
+	typedef std::unordered_map<state, double, RegularHash> DistanceList;
 
 	// traces back the path from q using the closed list
 	void trace_back_path( QueueNode q, std::vector<state> &path );

--- a/environments/CanonicalGrid.cpp
+++ b/environments/CanonicalGrid.cpp
@@ -7,7 +7,6 @@
 //
 
 #include "CanonicalGrid.h"
-#include <string.h>
 #include "SVGUtil.h"
 #include "Graphics.h"
  #include <string.h>
@@ -1031,7 +1030,7 @@ namespace CanonicalGrid {
 				bool found;
 				do {
 					found = false;
-					for (int x = 0; x < lines.size(); x++)
+					for (size_t x = 0; x < lines.size(); x++)
 					{
 						if (lines[x].first == points.back())
 						{

--- a/environments/DynamicWeightedGrid.h
+++ b/environments/DynamicWeightedGrid.h
@@ -907,7 +907,7 @@ namespace DWG {
 		int regionOffsetX = (sector%GetNumXSectors())*sectorSize;
 		int regionOffsetY = (sector/GetNumXSectors())*sectorSize;
 		uint16_t largest = 0;
-		for (int x = 1; x < s.regionCenters.size(); x++)
+		for (size_t x = 1; x < s.regionCenters.size(); x++)
 		{
 			if (s.regionCenters[x].count > s.regionCenters[largest].count)
 				largest = x;

--- a/environments/Fling.cpp
+++ b/environments/Fling.cpp
@@ -160,7 +160,7 @@ bool FlingBoard::CanMove(int which, int x, int y) const
 int FlingBoard::GetIndexInLocs(int offset) const
 {
 	// could do a binary search; TODO: profile to see if necessary
-	for (int i = 0; i < locs.size(); i++)
+	for (size_t i = 0; i < locs.size(); i++)
 	{
 		if (locs[i].first == offset)
 		{
@@ -262,9 +262,9 @@ void GetMirror(const FlingBoard &in, FlingBoard &out, bool h, bool v)
 {
 	out = in;
 	out.Reset();
-	for (int x = 0; x < in.width; x++)
+	for (size_t x = 0; x < in.width; x++)
 	{
-		for (int y = 0; y < in.height; y++)
+		for (size_t y = 0; y < in.height; y++)
 		{
 			if (in.HasPiece(x, y))
 			{
@@ -286,7 +286,7 @@ void ShiftToCorner(FlingBoard &in)
 	while (1)
 	{
 		// find piece
-		for (int x = 0; x < in.width; x++)
+		for (size_t x = 0; x < in.width; x++)
 		{
 			if (in.HasPiece(x, 0))
 			{
@@ -297,9 +297,9 @@ void ShiftToCorner(FlingBoard &in)
 		
 		if (done) break;
 		// move over
-		for (int y = 1; y < in.height; y++)
+		for (size_t y = 1; y < in.height; y++)
 		{
-			for (int x = 0; x < in.width; x++)
+			for (size_t x = 0; x < in.width; x++)
 			{
 				if (in.HasPiece(x, y))
 				{
@@ -311,7 +311,7 @@ void ShiftToCorner(FlingBoard &in)
 	}
 	while (1)
 	{
-		for (int y = 0; y < in.height; y++)
+		for (size_t y = 0; y < in.height; y++)
 		{
 			if (in.HasPiece(0, y))
 			{
@@ -319,9 +319,9 @@ void ShiftToCorner(FlingBoard &in)
 			}
 		}
 		
-		for (int x = 1; x < in.width; x++)
+		for (size_t x = 1; x < in.width; x++)
 		{
-			for (int y = 0; y < in.height; y++)
+			for (size_t y = 0; y < in.height; y++)
 			{
 				if (in.HasPiece(x, y))
 				{
@@ -440,7 +440,7 @@ void Fling::GetActions(const FlingBoard &nodeID, std::vector<FlingMove> &actions
 {
 	actions.resize(0);
 	FlingMove m;
-	for (unsigned int x = 0; x < nodeID.locs.size(); x++)
+	for (size_t x = 0; x < nodeID.locs.size(); x++)
 	{
 		if (nodeID.CanMove(nodeID.locs[x].first, 1, 0))
 		{
@@ -1093,5 +1093,3 @@ int64_t Fling::bi(unsigned int n, unsigned int k)
 	}
 	return num / den;
 }
-
-

--- a/environments/GraphEnvironment.h
+++ b/environments/GraphEnvironment.h
@@ -10,14 +10,16 @@
 #ifndef GRAPHENVIRONMENT_H
 #define GRAPHENVIRONMENT_H
 
-#include <stdint.h>
-#include <ext/hash_map>
-#include <iostream>
+
 #include "SearchEnvironment.h"
 #include "UnitSimulation.h"
 #include "Graph.h"
 //#include "GraphAbstraction.h"
 #include "GLUtil.h"
+
+#include <iostream>
+#include <stdint.h>
+#include <unordered_map>
 
 #ifndef UINT32_MAX
 #define UINT32_MAX        4294967295U

--- a/environments/GraphRefinementEnvironment.h
+++ b/environments/GraphRefinementEnvironment.h
@@ -11,7 +11,7 @@
 #define GRAPHREFINEMENTENVIRONMENT_H
 
 #include <stdint.h>
-#include <ext/hash_map>
+#include <unordered_map>
 #include <iostream>
 #include "GraphEnvironment.h"
 #include "GraphAbstraction.h"
@@ -36,7 +36,7 @@ public:
 	double HCost(const graphState &) const { assert(false); return false; }
 private:
 	GraphAbstraction *ga;
-	typedef __gnu_cxx::hash_map<graphState, bool> CorridorCheck;
+	typedef std::unordered_map<graphState, bool> CorridorCheck;
 	int planLevel, corridorLevel, abstractGoalLevel;
 	bool useAbstractGoal;
 	CorridorCheck corridorTable;

--- a/environments/MNPuzzle.h
+++ b/environments/MNPuzzle.h
@@ -30,14 +30,14 @@ public:
 	}
 	void Reset()
 	{
-		for (unsigned int x = 0; x < size(); x++)
+		for (size_t x = 0; x < size(); x++)
 			puzzle[x] = x;
 		blank = 0;
 	}
 	size_t size() const { return width*height; }
 	void FinishUnranking()
 	{
-		for (int x = 0; x < size(); x++)
+		for (size_t x = 0; x < size(); x++)
 		{
 			if (puzzle[x] == 0)
 			{
@@ -48,7 +48,7 @@ public:
 	}
 	bool operator<(const MNPuzzleState &b)
 	{
-		for (int x = 0; x < size(); x++)
+		for (size_t x = 0; x < size(); x++)
 			if (puzzle[x] != b.puzzle[x])
 				return puzzle[x] < b.puzzle[x];
 		return false;
@@ -89,7 +89,7 @@ template <int width, int height>
 static std::ostream& operator <<(std::ostream & out, const MNPuzzleState<width, height> &loc)
 {
 	out << "(" << width << "x" << height << ")";
-	for (unsigned int x = 0; x < loc.size(); x++)
+	for (size_t x = 0; x < loc.size(); x++)
 		out << loc.puzzle[x] << " ";
 	return out;
 }

--- a/environments/Map2DHeading.h
+++ b/environments/Map2DHeading.h
@@ -9,12 +9,12 @@
 #ifndef __hog2_glut__Map2DHeading__
 #define __hog2_glut__Map2DHeading__
 
-#include <iostream>
 #include "SearchEnvironment.h"
 #include "Map.h"
-#include <ext/hash_map>
 
 #include <cassert>
+#include <iostream>
+#include <unordered_map>
 
 //#include "BaseMapOccupancyInterface.h"
 
@@ -110,7 +110,7 @@ protected:
 	double GetCost(const xyhLoc &a, const xyhLoc &b, double P, double d) const;
 
 	struct hdData { double seen; double dist; };
-	typedef __gnu_cxx::hash_map<uint64_t, hdData, Hash64> CostTable;
+	typedef std::unordered_map<uint64_t, hdData, Hash64> CostTable;
 	CostTable costs;
 	bool LegalState(const xyhLoc &s);
 	void BuildAngleTables();

--- a/environments/NaryTree.cpp
+++ b/environments/NaryTree.cpp
@@ -22,7 +22,7 @@ NaryTree::NaryTree(int branchingFactor, int depth) :b(branchingFactor), d(depth)
 		tot*=b;
 		sum += tot;
 	}
-	for (int x = 0; x < nodesAtDepth.size(); x++)
+	for (size_t x = 0; x < nodesAtDepth.size(); x++)
 	{
 		printf("%d %llu %llu\n", x, nodesAtDepth[x], totalNodesAtDepth[x]);
 	}

--- a/environments/PancakePuzzle.h
+++ b/environments/PancakePuzzle.h
@@ -719,7 +719,7 @@ void PancakePuzzle<N>::OpenGLDraw(const PancakePuzzleState<N> &pps) const
 	double count = pps.size();
 	double widthUnit = 1.5/count;
 	
-	for (int y = 0; y < pps.size(); y++)
+	for (size_t y = 0; y < pps.size(); y++)
 	{
 		for (int x = 0; x <= pps.puzzle[y]; x++)
 		{

--- a/environments/PermutationPuzzleEnvironment.h
+++ b/environments/PermutationPuzzleEnvironment.h
@@ -70,7 +70,7 @@ namespace PermutationPuzzle {
 			MR1KPermutation mr1;
 			state tmp = s;
 			state dual;
-			for (int x = 0; x < tmp.size(); x++)
+			for (size_t x = 0; x < tmp.size(); x++)
 				dual.puzzle[tmp.puzzle[x]] = x;
 			return mr1.Rank(tmp.puzzle, dual.puzzle, s.size(), s.size());
 		}
@@ -1285,7 +1285,7 @@ namespace PermutationPuzzle {
 	{
 		state tmp = s;
 		state dual;
-		for (int x = 0; x < tmp.size(); x++)
+		for (size_t x = 0; x < tmp.size(); x++)
 			dual.puzzle[tmp.puzzle[x]] = x;
 
 		uint64_t hash = mr1.Rank(&tmp.puzzle[0], &dual.puzzle[0], s.size(), s.size());
@@ -1297,11 +1297,11 @@ namespace PermutationPuzzle {
 	{
 		state dual;
 		state result;
-		for (int x = 0; x < b.size(); x++)
+		for (size_t x = 0; x < b.size(); x++)
 		{
 			dual.puzzle[b.puzzle[x]] = x;
 		}
-		for (int x = 0; x < b.size(); x++)
+		for (size_t x = 0; x < b.size(); x++)
 		{
 			result.puzzle[x] = dual.puzzle[a.puzzle[x]];
 		}
@@ -1359,21 +1359,21 @@ namespace PermutationPuzzle {
 	template <class state, class action>
 	bool PermutationPuzzleEnvironment<state, action>::Check_Permutation(const std::vector<int> &to_check)
 	{
-		unsigned size = to_check.size();
+		const auto size = to_check.size();
 		
 		bool in_puzzle[size];
 		
-		for (unsigned i = 0; i < size; i++)
+		for (size_t i = 0; i < size; i++)
 		{
 			in_puzzle[i] = false;
 		}
 		
-		for (unsigned i = 0; i < size; i++)
+		for (size_t i = 0; i < size; i++)
 		{
 			in_puzzle[to_check[i]] = true;
 		}
 		
-		for (unsigned i = 0; i < size; i++)
+		for (size_t i = 0; i < size; i++)
 		{
 			if (!in_puzzle[i])
 				return false;

--- a/environments/RoadMap.cpp
+++ b/environments/RoadMap.cpp
@@ -8,6 +8,8 @@
 
 #include "RoadMap.h"
 
+#include <algorithm>
+
 
 RoadMap::RoadMap(const char *graph, const char *coordinates, bool timeGraph)
 {

--- a/environments/RubiksCubeCorners.cpp
+++ b/environments/RubiksCubeCorners.cpp
@@ -1429,7 +1429,7 @@ std::string RubikCornerPDB::GetFileName(const char *prefix)
 	fileName.pop_back();
 	fileName += "-";
 	// pattern
-	for (int x = 0; x < corners.size(); x++)
+	for (size_t x = 0; x < corners.size(); x++)
 	{
 		fileName += std::to_string(corners[x]);
 		fileName += ";";

--- a/environments/RubiksCubeEdges.cpp
+++ b/environments/RubiksCubeEdges.cpp
@@ -1262,7 +1262,7 @@ void RubikEdge::SetCubeColor(int which, bool face, const RubikEdgeState &s) cons
 RubikEdgePDB::RubikEdgePDB(RubikEdge *e, const RubikEdgeState &s, std::vector<int> &distinctEdges)
 :PDBHeuristic(e), edges(distinctEdges), puzzles(std::thread::hardware_concurrency())
 {
-	for (int x = 0; x < puzzles.size(); x++)
+	for (size_t x = 0; x < puzzles.size(); x++)
 		puzzles[x].resize(12);
 	SetGoal(s);
 }
@@ -1549,7 +1549,7 @@ std::string RubikEdgePDB::GetFileName(const char *prefix)
 	fileName.pop_back();
 	fileName += "-";
 	// denote the pattern used for the PDB
-	for (int x = 0; x < edges.size(); x++)
+	for (size_t x = 0; x < edges.size(); x++)
 	{
 		fileName += std::to_string(edges[x]);
 		fileName += ";";
@@ -1712,5 +1712,3 @@ std::string RubikEdgeOrientationPDB::GetFileName(const char *prefix)
 	fileName += "RC-E12-OR.pdb";
 	return fileName;
 }
-
-

--- a/environments/SnakeBird.cpp
+++ b/environments/SnakeBird.cpp
@@ -707,7 +707,7 @@ bool SnakeBird::Render(const SnakeBirdState &s) const
 		}
 	}
 	// render fruit into world
-	for (int f = 0; f < fruit.size(); f++)
+	for (size_t f = 0; f < fruit.size(); f++)
 	{
 		if (s.GetFruitPresent(f))
 			render[fruit[f]] = kFruit;
@@ -1085,13 +1085,13 @@ SnakeBirdAnimation SnakeBird::DoFall(SnakeBirdAction &a, SnakeBirdState &s) cons
 	a.pushed = falling;
 	
 	// check if an object hit the bottom of the world - if so it is dead
-	for (int i = 0; i < objects.size(); i++)
+	for (size_t i = 0; i < objects.size(); i++)
 	{
 		int objLoc = s.GetObjectLocation(i);
 		if (objLoc == kDead)
 			continue;
 		int objectY = GetY(objLoc);
-		for (int j = 0; j < objects[i].size(); j++)
+		for (size_t j = 0; j < objects[i].size(); j++)
 		{
 			if (objectY+GetY(objects[i][j]) >= height-2)
 			{
@@ -1487,7 +1487,7 @@ TeleportResult SnakeBird::HandleTeleports(SnakeBirdState &s, SnakeBirdAction &a,
 			int newloc = s.GetObjectLocation(object);
 			if (newloc == kDead)
 				continue;
-			for (int x = 0; x < objects[object].size(); x++)
+			for (size_t x = 0; x < objects[object].size(); x++)
 			{
 				int piece = GetIndex(GetX(objects[object][x])+GetX(newloc),
 									 GetY(objects[object][x])+GetY(newloc));
@@ -1535,7 +1535,7 @@ TeleportResult SnakeBird::HandleTeleports(SnakeBirdState &s, SnakeBirdAction &a,
 
 					// Validate if the object can be placed in the new location
 					bool valid = true;
-					for (int v = 0; v < objects[object].size(); v++)
+					for (size_t v = 0; v < objects[object].size(); v++)
 					{
 						if (GetX(newloc)+GetX(objects[object][v])+xChange < 0 ||
 							GetX(newloc)+GetX(objects[object][v])+xChange >= width ||
@@ -1598,7 +1598,7 @@ void SnakeBird::RemoveBlock(int x, int y)
 		xOffset = GetX(startState.GetObjectLocation(which));
 		yOffset = GetY(startState.GetObjectLocation(which));
 
-		for (int i = 0; i < objects[which].size(); i++)
+		for (size_t i = 0; i < objects[which].size(); i++)
 		{
 			if (GetX(objects[which][i])+xOffset == x &&
 				GetY(objects[which][i])+yOffset == y) // remove
@@ -1617,13 +1617,13 @@ void SnakeBird::RemoveBlock(int x, int y)
 		int newX = width, newY=height;
 		
 		// Get new base location (minx/y)
-		for (int i = 0; i < objects[which].size(); i++)
+		for (size_t i = 0; i < objects[which].size(); i++)
 		{
 			newX = std::min(newX, GetX(objects[which][i])+xOffset);
 			newY = std::min(newY, GetY(objects[which][i])+yOffset);
 		}
 		startState.SetObjectLocation(which, GetIndex(newX, newY));
-		for (int i = 0; i < objects[which].size(); i++)
+		for (size_t i = 0; i < objects[which].size(); i++)
 		{
 			// reset locations based on new base location
 			objects[which][i] = GetIndex(GetX(objects[which][i])+xOffset - newX,

--- a/environments/TopSpinGraph.h
+++ b/environments/TopSpinGraph.h
@@ -7,7 +7,7 @@
  *
  */
 
-//#include <ext/hash_map>
+//#include <unordered_map>
 #include "GraphEnvironment.h"
 
 //#include "ts.h"
@@ -62,7 +62,7 @@ public:
 	uint64_t GetPDBHash(const graphState &state, int pdb_size) const;
 	uint64_t GetPDBSize(int puzzle_size, int pdb_size) const;
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, unsigned long, Hash64> TopSpinHashTable;
+	typedef std::unordered_map<uint64_t, unsigned long, Hash64> TopSpinHashTable;
 
 	void ExpandNode(const graphState &stateID) const;
 	void Flip(std::vector<int> &arrangement, int index, int radius) const;

--- a/environments/VoxelGrid.cpp
+++ b/environments/VoxelGrid.cpp
@@ -424,7 +424,7 @@ void VoxelGrid::SetUpDrawBuffers()
 	VoxelUtils::GetTriangles(this, data);
 	std::unordered_map<VoxelUtils::vn, int> index;
 	int next = 0;
-	for (int x = 0; x < data.size(); x++)
+	for (size_t x = 0; x < data.size(); x++)
 	{
 		for (int y = 0; y < 3; y++)
 		{
@@ -467,7 +467,7 @@ void VoxelGrid::SetUpDrawBuffers()
 	}
 	printf("%d individual items\n", next);
 	// get list of surface triangles, normals, and colors
-	for (int x = 0; x < data.size(); x++)
+	for (size_t x = 0; x < data.size(); x++)
 	{
 		for (int y = 0; y < 3; y++)
 		{

--- a/environments/Voxels.cpp
+++ b/environments/Voxels.cpp
@@ -144,7 +144,7 @@ void Voxels::Export(const char *filename)
 	
 	fprintf(f, "voxel %d %d %d\n", maxx-minx+1+2*buffer, maxy-miny+1+2*buffer, maxz-minz+1+2*buffer);
 
-	for (int x = 0; x < w.numVoxelsGrids; x++)
+	for (size_t x = 0; x < w.numVoxelsGrids; x++)
 	{
 		point3d p = GetVoxelCoordinate(w.morton[x], w.voxelSize, w.minbounds);
 		for (int i = 0; i < 64; i++)
@@ -253,7 +253,7 @@ void Voxels::OpenGLDraw() const
 	double yRange = max(w.maxbounds[1],-w.minbounds[1]);
 	double zRange = max(w.maxbounds[2],-w.minbounds[2]);
 	double range = std::max(xRange, std::max(yRange, zRange));
-	for (int x = 0; x < w.numVoxelsGrids; x++)
+	for (size_t x = 0; x < w.numVoxelsGrids; x++)
 	{
 		point3d p = GetVoxelCoordinate(w.morton[x], w.voxelSize, w.minbounds);
 		bool drawFrame = false;

--- a/environments/WeightedMap2DEnvironment.h
+++ b/environments/WeightedMap2DEnvironment.h
@@ -34,7 +34,6 @@
 #include "BitVector.h"
 #include "OccupancyInterface.h"
 #include "Graph.h"
-#include <ext/hash_map>
 #include <cmath>
 #include <unordered_map>
 
@@ -108,7 +107,7 @@ namespace AngleUtil {
 		size_t operator()(const AngleSearchNode &x) const
 		{ return (size_t)(x.hashKey); } };
 	
-	 typedef __gnu_cxx::hash_map<AngleUtil::AngleSearchNode,Vector2D, AngleUtil::SearchNodeHash, AngleUtil::SearchNodeEqual> AngleLookupTable;
+	 typedef std::unordered_map<AngleUtil::AngleSearchNode,Vector2D, AngleUtil::SearchNodeHash, AngleUtil::SearchNodeEqual> AngleLookupTable;
 };
 
 /** Edge labels */
@@ -168,7 +167,7 @@ public:
 private:
 	BaseMapOccupancyInterface* oi;
 	
-	//typedef __gnu_cxx::hash_map<AngleUtil::AngleSearchNode,Vector2D, AngleUtil::SearchNodeHash, AngleUtil::SearchNodeEqual>
+	//typedef std::unordered_map<AngleUtil::AngleSearchNode,Vector2D, AngleUtil::SearchNodeHash, AngleUtil::SearchNodeEqual>
 	typedef std::unordered_map<AngleUtil::AngleSearchNode,Vector2D, AngleUtil::SearchNodeHash, AngleUtil::SearchNodeEqual> AngleLookupTable;
 	AngleLookupTable angleLookup;
 	
@@ -202,4 +201,3 @@ typedef UnitSimulation<xyLoc, tDirection, WeightedMap2DEnvironment> UnitWeighted
 
 
 #endif
-

--- a/generic/AStarEpsilon.h
+++ b/generic/AStarEpsilon.h
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 #include "TemplateAStar.h"

--- a/generic/BFS.h
+++ b/generic/BFS.h
@@ -10,11 +10,12 @@
 #ifndef BFS_H
 #define BFS_H
 
-#include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
-#include <unordered_map>
 #include "FPUtil.h"
+
+#include <algorithm>
+#include <iostream>
+#include <unordered_map>
 
 template <class state, class action, class environment>
 class BFS {
@@ -43,7 +44,7 @@ private:
 template <class state, class action, class environment>
 void BFS<state, action, environment>::DoBFS(environment *env, state from)
 {
-//	typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64> BFSClosedList;
+//	typedef std::unordered_map<uint64_t, bool, Hash64> BFSClosedList;
 //	BFSClosedList mClosed; // store parent id!
 	std::deque<state> mOpen;
 	std::deque<int> depth;
@@ -114,7 +115,7 @@ void BFS<state, action, environment>::GetPath(environment *env,
 								 state from, state to,
 								 std::vector<state> &thePath)
 {
-//	typedef __gnu_cxx::hash_map<uint64_t, uint64_t, Hash64> BFSClosedList;
+//	typedef std::unordered_map<uint64_t, uint64_t, Hash64> BFSClosedList;
 	std::deque<std::pair<state, uint16_t>> mOpen;
 	//std::deque<int> depth;
 	std::unordered_map<state, state> mClosed; // store parent with each state

--- a/generic/DFID.h
+++ b/generic/DFID.h
@@ -12,10 +12,10 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 
-typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 template <class state, class action>
 class DFID {

--- a/generic/DFS.h
+++ b/generic/DFS.h
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 
 template <class state, class action>
@@ -28,7 +28,7 @@ public:
 	uint64_t GetNodesExpanded() { return nodesExpanded; }
 	uint64_t GetNodesTouched() { return nodesTouched; }
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64> DFSClosedList;
+	typedef std::unordered_map<uint64_t, bool, Hash64> DFSClosedList;
 	
 	void DoIteration(SearchEnvironment<state, action> *env,
 					 state parent, state currState,

--- a/generic/DynamicPotentialSearch.h
+++ b/generic/DynamicPotentialSearch.h
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 #include "TemplateAStar.h"

--- a/generic/EBSearch.h
+++ b/generic/EBSearch.h
@@ -283,7 +283,7 @@ typename EBSearch<state, action, environment, DFS>::searchData EBSearch<state, a
 	sd.nodes++;
 	totalNodesTouched+=acts.size();
 
-	for (int x = 0; x < acts.size(); x++)
+	for (size_t x = 0; x < acts.size(); x++)
 	{
 		if (acts[x] == forbidden && currPath.size() > 0)
 			continue;
@@ -342,9 +342,11 @@ typename EBSearch<state, action, environment, DFS>::searchData EBSearch<state, a
 			// Path is backwards - reverse
 			reverse(solutionStates.begin(), solutionStates.end());
 			// f, nextF, failedF, nodes
-			for (int x = 0; x < solutionStates.size()-1; x++)
-			{
-				solutionPath.push_back(env->GetAction(solutionStates[x], solutionStates[x+1]));
+			if(solutionStates.size() > 0) {
+				for (size_t x = 0; x < solutionStates.size()-1; x++)
+				{
+					solutionPath.push_back(env->GetAction(solutionStates[x], solutionStates[x+1]));
+				}
 			}
 			return {static_cast<uint64_t>(q.Lookup(nodeid).g), static_cast<uint64_t>(q.Lookup(nodeid).g), -1ull, nodesExpanded};
 		}
@@ -360,7 +362,7 @@ typename EBSearch<state, action, environment, DFS>::searchData EBSearch<state, a
 		env->GetSuccessors(q.Lookup(nodeid).data, neighbors);
 
 		// 1. load all the children
-		for (unsigned int x = 0; x < neighbors.size(); x++)
+		for (size_t x = 0; x < neighbors.size(); x++)
 		{
 			uint64_t theID;
 			neighborLoc.push_back(q.Lookup(env->GetStateHash(neighbors[x]), theID));
@@ -369,7 +371,7 @@ typename EBSearch<state, action, environment, DFS>::searchData EBSearch<state, a
 		}
 		
 		// iterate again updating costs and writing out to memory
-		for (int x = 0; x < neighbors.size(); x++)
+		for (size_t x = 0; x < neighbors.size(); x++)
 		{
 			totalNodesTouched++;
 			
@@ -446,4 +448,3 @@ typename EBSearch<state, action, environment, DFS>::searchData EBSearch<state, a
 		return BFHS(costLimit, nodeLimit);
 }
 #endif /* BID_h */
-

--- a/generic/EDAStar.h
+++ b/generic/EDAStar.h
@@ -12,12 +12,12 @@
 #include <iostream>
 #include <functional>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "vectorCache.h"
 
 
-typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 template <class state, class action, bool verbose = true>
 class EDAStar {
@@ -153,4 +153,3 @@ void EDAStar<state, action, verbose>::DoIteration(SearchEnvironment<state, actio
 }
 
 #endif
-

--- a/generic/EPEAStar.h
+++ b/generic/EPEAStar.h
@@ -37,7 +37,7 @@
 #endif
 
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 //#include "SearchEnvironment.h" // for the SearchEnvironment class

--- a/generic/Focal.h
+++ b/generic/Focal.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 #include "TemplateAStar.h"

--- a/generic/FocalAdd.h
+++ b/generic/FocalAdd.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 #include "FPUtil.h"
-//#include <ext/hash_map>
+//#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 #include "TemplateAStar.h"

--- a/generic/FrontierBFS.h
+++ b/generic/FrontierBFS.h
@@ -12,10 +12,10 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 
-typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64> FrontierBFSClosedList;
+typedef std::unordered_map<uint64_t, bool, Hash64> FrontierBFSClosedList;
 
 template <class state, class action>
 class FrontierBFS {

--- a/generic/GraphCheck.h
+++ b/generic/GraphCheck.h
@@ -11,7 +11,7 @@
 
 #include <stdint.h>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "SearchEnvironment.h"
 #include "UnitSimulation.h"
 #include "Graph.h"
@@ -45,10 +45,10 @@ template <typename state, typename action>
 class GraphCheck {
 public:
 	static void NumNodesWithinRadius(SearchEnvironment<state, action> &env, state from, int depth, int &inner_count, int &leaf_count);
-	static void PathCountWithinRadius(SearchEnvironment<state, action> &env, state from, int depth, __gnu_cxx::hash_map<uint64_t, int, Hash64> &counts, __gnu_cxx::hash_map<uint64_t, double, Hash64> &aveCosts );
+	static void PathCountWithinRadius(SearchEnvironment<state, action> &env, state from, int depth, std::unordered_map<uint64_t, int, Hash64> &counts, std::unordered_map<uint64_t, double, Hash64> &aveCosts );
 
 private:
-	static void DFSVisit(SearchEnvironment<state, action> &env, std::vector<SimpleNode<state> > &thePath, int depth, __gnu_cxx::hash_map<uint64_t, int, Hash64> &counts, __gnu_cxx::hash_map<uint64_t, double, Hash64> &aveCosts, double gval);
+	static void DFSVisit(SearchEnvironment<state, action> &env, std::vector<SimpleNode<state> > &thePath, int depth, std::unordered_map<uint64_t, int, Hash64> &counts, std::unordered_map<uint64_t, double, Hash64> &aveCosts, double gval);
 
 };
 
@@ -59,7 +59,7 @@ void GraphCheck<state, action>::NumNodesWithinRadius(SearchEnvironment<state, ac
 	inner_count = 0;
 	leaf_count = 0;
 	std::queue<SimpleNode<state> > myqueue;
-	__gnu_cxx::hash_map<uint64_t, SimpleNode<state>, Hash64> closedlist;
+	std::unordered_map<uint64_t, SimpleNode<state>, Hash64> closedlist;
 
 	std::vector<state> neighbors;
 
@@ -104,7 +104,7 @@ void GraphCheck<state, action>::NumNodesWithinRadius(SearchEnvironment<state, ac
 }
 
 template <typename state, typename action>
-void GraphCheck<state, action>::PathCountWithinRadius(SearchEnvironment<state, action> &env, state from, int depth, __gnu_cxx::hash_map<uint64_t, int, Hash64> &counts, __gnu_cxx::hash_map<uint64_t, double, Hash64> &aveCosts )
+void GraphCheck<state, action>::PathCountWithinRadius(SearchEnvironment<state, action> &env, state from, int depth, std::unordered_map<uint64_t, int, Hash64> &counts, std::unordered_map<uint64_t, double, Hash64> &aveCosts )
 {
 	// using recursive version of DFS
 	std::vector<SimpleNode<state> > thePath;
@@ -115,7 +115,7 @@ void GraphCheck<state, action>::PathCountWithinRadius(SearchEnvironment<state, a
 
 	DFSVisit(env, thePath,depth,counts,aveCosts,0);
 
-	for (__gnu_cxx::hash_map<uint64_t,int, Hash64> ::iterator it = counts.begin(); it != counts.end(); it++)
+	for (std::unordered_map<uint64_t,int, Hash64> ::iterator it = counts.begin(); it != counts.end(); it++)
 	{
 		if (it->second > 0)
 			aveCosts[it->first] /= it->second;
@@ -123,7 +123,7 @@ void GraphCheck<state, action>::PathCountWithinRadius(SearchEnvironment<state, a
 }
 
 template <typename state, typename action>
-void GraphCheck<state, action>::DFSVisit(SearchEnvironment<state, action> &env, std::vector<SimpleNode<state> > &thePath, int depth, __gnu_cxx::hash_map<uint64_t, int, Hash64> &counts, __gnu_cxx::hash_map<uint64_t, double, Hash64> &aveCosts, double gval)
+void GraphCheck<state, action>::DFSVisit(SearchEnvironment<state, action> &env, std::vector<SimpleNode<state> > &thePath, int depth, std::unordered_map<uint64_t, int, Hash64> &counts, std::unordered_map<uint64_t, double, Hash64> &aveCosts, double gval)
 {
 	std::vector<state> neighbors;
 

--- a/generic/IBEX.h
+++ b/generic/IBEX.h
@@ -260,7 +260,7 @@ namespace IBEX {
 		sd.nodes++;
 		totalNodesTouched+=acts.size();
 		
-		for (int x = 0; x < acts.size(); x++)
+		for (size_t x = 0; x < acts.size(); x++)
 		{
 			if (acts[x] == forbidden && currPath.size() > 0)
 				continue;
@@ -356,7 +356,7 @@ namespace IBEX {
 			env->GetSuccessors(q.Lookup(nodeid).data, neighbors);
 			
 			// 1. load all the children
-			for (unsigned int x = 0; x < neighbors.size(); x++)
+			for (size_t x = 0; x < neighbors.size(); x++)
 			{
 				uint64_t theID;
 				neighborLoc.push_back(q.Lookup(env->GetStateHash(neighbors[x]), theID));
@@ -365,7 +365,7 @@ namespace IBEX {
 			}
 			
 			// iterate again updating costs and writing out to memory
-			for (int x = 0; x < neighbors.size(); x++)
+			for (size_t x = 0; x < neighbors.size(); x++)
 			{
 				totalNodesTouched++;
 			

--- a/generic/IDAStar.h
+++ b/generic/IDAStar.h
@@ -13,13 +13,13 @@
 #include <iostream>
 #include <functional>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "vectorCache.h"
 
 //#define DO_LOGGING
 
-typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 template <class state, class action, bool verbose = true>
 class IDAStar {
@@ -278,4 +278,3 @@ void IDAStar<state, action, verbose>::UpdateNextBound(double currBound, double f
 
 
 #endif
-

--- a/generic/IDAStarCR.h
+++ b/generic/IDAStarCR.h
@@ -12,12 +12,12 @@
 #include <iostream>
 #include <functional>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "vectorCache.h"
 
 
-typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 template <class state, class action, int buckets = 50, bool verbose = true>
 class IDAStarCR {
@@ -152,4 +152,3 @@ void IDAStarCR<state, action, buckets, verbose>::DoIteration(SearchEnvironment<s
 }
 
 #endif
-

--- a/generic/IncrementalBTS.h
+++ b/generic/IncrementalBTS.h
@@ -201,7 +201,7 @@ bool IncrementalBTS<state, action>::StepIteration()
 		if (fless(search.back().pathCost, solutionCost))
 		{
 			solutionPath.clear();
-			for (int x = 0; x < search.size(); x++)
+			for (size_t x = 0; x < search.size(); x++)
 				solutionPath.push_back(search[x].currState);
 			solutionCost = search.back().pathCost;
 			printf("Found solution cost %f!", solutionCost);
@@ -244,7 +244,7 @@ bool IncrementalBTS<state, action>::StepIteration()
 		search.back().status = kGoingAcross;
 		env->GetSuccessors(search.back().currState, search.back().succ);
 		nodesExpanded++;
-		for (int x = 0; x < search.back().succ.size(); x++)
+		for (size_t x = 0; x < search.back().succ.size(); x++)
 		{
 			if (search.size() > 1 && search.back().succ[x] == search[search.size()-2].currState)
 			{
@@ -395,7 +395,7 @@ bool IncrementalBTS<state, action>::DoSingleSearchStep(std::vector<state> &thePa
 template <class state, class action>
 void IncrementalBTS<state, action>::Draw(Graphics::Display &display) const
 {
-	for (int x = 1; x < search.size(); x++)
+	for (size_t x = 1; x < search.size(); x++)
 	{
 		env->DrawLine(display, search[x-1].currState, search[x].currState, 10);
 	}
@@ -406,7 +406,7 @@ void IncrementalBTS<state, action>::OpenGLDraw()
 {
 	//	for (auto x : history)
 	//		env->OpenGLDraw(x.first);
-	for (int x = 1; x < search.size(); x++)
+	for (size_t x = 1; x < search.size(); x++)
 		env->GLDrawLine(search[x-1].currState, search[x].currState, 10);
 	//	for (int x = 1; x < path.size(); x++)
 	//		env->GLDrawLine(path[x-1], path[x]);

--- a/generic/IncrementalIDA.h
+++ b/generic/IncrementalIDA.h
@@ -11,6 +11,8 @@
 
 #include "Heuristic.h"
 
+#include <algorithm>
+
 template <class state, class action>
 class IncrementalIDA {
 public:
@@ -131,7 +133,7 @@ bool IncrementalIDA<state, action>::StepIteration()
 	{
 		printf("Done!");
 		path.resize(0);
-		for (int x = 0; x < search.size(); x++)
+		for (size_t x = 0; x < search.size(); x++)
 			path.push_back(search[x].currState);
 		return true;
 	}
@@ -160,7 +162,7 @@ bool IncrementalIDA<state, action>::StepIteration()
 		search.back().status = kGoingAcross;
 		env->GetSuccessors(search.back().currState, search.back().succ);
 		nodesExpanded++;
-		for (int x = 0; x < search.back().succ.size(); x++)
+		for (size_t x = 0; x < search.back().succ.size(); x++)
 		{
 			if (search.size() > 1 && search.back().succ[x] == search[search.size()-2].currState)
 			{

--- a/generic/NBS.h
+++ b/generic/NBS.h
@@ -129,9 +129,9 @@ private:
 	void ExtractPathToStart(state &node, std::vector<state> &thePath)
 	{
 		uint64_t theID;
-		auto loc = queue.forwardQueue.Lookup(env->GetStateHash(node), theID);
 		ExtractPathToStartFromID(theID, thePath);
 	}
+
 	void ExtractPathToStartFromID(uint64_t node, std::vector<state> &thePath)
 	{
 		do {
@@ -344,7 +344,6 @@ void NBS<state, action, environment, dataStructure, priorityQueue>::Expand(uint6
 			{
 				if (fless(current.Lookup(nextID).g+edgeCost, current.Lookup(childID).g))
 				{
-					double oldGCost = current.Lookup(childID).g;
 					current.Lookup(childID).parentID = nextID;
 					current.Lookup(childID).g = current.Lookup(nextID).g+edgeCost;
 					current.KeyChanged(childID);

--- a/generic/OldTemplateAStar.h
+++ b/generic/OldTemplateAStar.h
@@ -39,7 +39,7 @@
 #endif
 
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "OpenClosedList.h"
 //#include "SearchEnvironment.h" // for the SearchEnvironment class
 #include "float.h"
@@ -114,7 +114,7 @@ public:
 	typedef OpenClosedList<OldOldTemplateAStarUtil::SearchNode<state>, OldOldTemplateAStarUtil::SearchNodeHash<state>,
 		OldOldTemplateAStarUtil::SearchNodeEqual<state>, OldOldTemplateAStarUtil::SearchNodeCompare<state> > PQueue;
 	
-	typedef __gnu_cxx::hash_map<uint64_t, OldOldTemplateAStarUtil::SearchNode<state>, Hash64 > NodeLookupTable;
+	typedef std::unordered_map<uint64_t, OldOldTemplateAStarUtil::SearchNode<state>, Hash64 > NodeLookupTable;
 	
 	PQueue openQueue;
 	NodeLookupTable closedList; //openList
@@ -587,7 +587,7 @@ int OldTemplateAStar<state, action,environment>::GetMemoryUsage()
  * @return An iterator pointing to the first node in the closed list
  */
 template <class state, class action,class environment>
-//__gnu_cxx::hash_map<state, OldOldTemplateAStarUtil::SearchNode<state> >::const_iterator
+//std::unordered_map<state, OldOldTemplateAStarUtil::SearchNode<state> >::const_iterator
 void OldTemplateAStar<state, action,environment>::GetClosedListIter(closedList_iterator) //const
 {
 	return closedList.begin();

--- a/generic/OptimisticSearch.h
+++ b/generic/OptimisticSearch.h
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 #include "TemplateAStar.h"

--- a/generic/PEAStar.h
+++ b/generic/PEAStar.h
@@ -37,7 +37,7 @@
 #endif
 
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
 //#include "SearchEnvironment.h" // for the SearchEnvironment class

--- a/generic/ParallelIDAStar.h
+++ b/generic/ParallelIDAStar.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "vectorCache.h"
 #include "SharedQueue.h"
@@ -110,7 +110,7 @@ void ParallelIDAStar<environment, state, action>::GetPath(environment *env,
 														  state from, state to,
 														  std::vector<action> &thePath)
 {
-	int numThreads = std::thread::hardware_concurrency();
+	const auto numThreads = std::thread::hardware_concurrency();
 	if (!storedHeuristic)
 		heuristic = env;
 	nextBound = 0;
@@ -133,7 +133,7 @@ void ParallelIDAStar<environment, state, action>::GetPath(environment *env,
 	// builds a list of all states at a fixed depth
 	// we will then search them in parallel
 	GenerateWork(env, act[0], from, thePath);
-	for (int x = 0; x < work.size(); x++)
+	for (size_t x = 0; x < work.size(); x++)
 		work[x].unitNumber = x;
 	printf("%lu pieces of work generated\n", work.size());
 	foundSolution = work.size() + 1;
@@ -149,11 +149,11 @@ void ParallelIDAStar<environment, state, action>::GetPath(environment *env,
 		printf("Starting iteration with bound %f; %llu expanded, %llu generated\n", nextBound, nodesExpanded, nodesTouched);
 		fflush(stdout);
 		
-		for (int x = 0; x < work.size(); x++)
+		for (size_t x = 0; x < work.size(); x++)
 		{
 			q.Add(x);
 		}
-		for (int x = 0; x < numThreads; x++)
+		for (size_t x = 0; x < numThreads; x++)
 		{
 			threads.push_back(new std::thread(&ParallelIDAStar<environment, state, action>::StartThreadedIteration, this,
 												 *env, from, nextBound));

--- a/generic/SFIDAStar.h
+++ b/generic/SFIDAStar.h
@@ -12,10 +12,10 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 
-typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 template <class state, class action>
 class SFIDAStar {

--- a/generic/TemplateAStar.h
+++ b/generic/TemplateAStar.h
@@ -24,7 +24,7 @@
 #include <iostream>
 #include "Constraint.h"
 #include "FPUtil.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "Graphics.h"
 #include "AStarOpenClosed.h"
 #include "BucketOpenClosed.h"
@@ -235,7 +235,7 @@ void TemplateAStar<state,action,environment,openList>::GetPath(environment *_env
 	while (!DoSingleSearchStep(thePath))
 	{
 	}
-	for (int x = 0; x < thePath.size()-1; x++)
+	for (size_t x = 0; x < thePath.size()-1; x++)
 	{
 		path.push_back(_env->GetAction(thePath[x], thePath[x+1]));
 	}
@@ -379,7 +379,7 @@ bool TemplateAStar<state,action,environment,openList>::DoSingleSearchStep(std::v
 	}
 	
 	// iterate again updating costs and writing out to memory
-	for (int x = 0; x < neighbors.size(); x++)
+	for (size_t x = 0; x < neighbors.size(); x++)
 	{
 		nodesTouched++;
 

--- a/generic/UnitCostBidirectionalBFS.h
+++ b/generic/UnitCostBidirectionalBFS.h
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 
 template <class state, class action>
@@ -28,7 +28,7 @@ public:
 	uint64_t GetNodesExpanded() { return nodesExpanded; }
 	uint64_t GetNodesTouched() { return nodesTouched; }
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, state, Hash64> BFSClosedList;
+	typedef std::unordered_map<uint64_t, state, Hash64> BFSClosedList;
 
 	bool ExtractPath(SearchEnvironment<state, action> *env,
 					 std::vector<state> &thePath);

--- a/graph/Graph.h
+++ b/graph/Graph.h
@@ -213,10 +213,14 @@ public:
 	void SetLabelF(unsigned int index, double val) const;
 	void SetLabelL(unsigned int index, long val) const;
 	inline double GetLabelF(unsigned int index) const {
-		if (index < label.size()) return label[index].fval; return MAXINT;
+		if (index < label.size())
+			return label[index].fval;
+		return MAXINT;
 	}
 	inline long GetLabelL(unsigned int index) const {
-		if (index < label.size()) return label[index].lval; return MAXINT;
+		if (index < label.size())
+			return label[index].lval;
+		return MAXINT;
 	}
 	
 	// set/get marked edge for each node (limit 1)

--- a/graphalgorithms/AStarDelay.h
+++ b/graphalgorithms/AStarDelay.h
@@ -14,7 +14,7 @@
 #include "GraphAlgorithm.h"
 #include "SearchEnvironment.h"
 #include "GraphEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "OpenListB.h"
 #include <deque>
@@ -32,7 +32,7 @@
 #define D_SQRT 6
 //const double pi = 3.141592654;
 
-//typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+//typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 namespace AStarDelayUtil
 {
@@ -112,7 +112,7 @@ namespace AStarDelayUtil
 	typedef OpenListB<AStarDelayUtil::SearchNode, AStarDelayUtil::SearchNodeHash,
 		AStarDelayUtil::SearchNodeEqual, AStarDelayUtil::SearchNodeCompare, AStarDelayUtil::GGreater, AStarDelayUtil::FExtract> PQueue;
 
-	typedef __gnu_cxx::hash_map<graphState, AStarDelayUtil::SearchNode > NodeLookupTable;
+	typedef std::unordered_map<graphState, AStarDelayUtil::SearchNode > NodeLookupTable;
 
 	typedef OpenListB<AStarDelayUtil::SearchNode, AStarDelayUtil::SearchNodeHash,
 		AStarDelayUtil::SearchNodeEqual, AStarDelayUtil::GGreater, AStarDelayUtil::GGreater, AStarDelayUtil::FExtract> GQueue;

--- a/graphalgorithms/MeroB.h
+++ b/graphalgorithms/MeroB.h
@@ -13,7 +13,7 @@
 #include "GraphAlgorithm.h"
 #include "SearchEnvironment.h"
 #include "GraphEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "OpenClosedList.h"
 
@@ -27,7 +27,7 @@
 #define MB_B 2
 #define MB_BP 3
 
-//typedef __gnu_cxx::hash_map<uint64_t, double> NodeHashTable;
+//typedef std::unordered_map<uint64_t, double> NodeHashTable;
 
 namespace MeroBUtil
 {
@@ -236,7 +236,7 @@ namespace MeroBUtil
 	typedef OpenClosedList<MeroBUtil::SearchNode, MeroBUtil::SearchNodeHash,
 		MeroBUtil::SearchNodeEqual, MeroBUtil::SearchNodeCompare> PQueue;
 
-	typedef __gnu_cxx::hash_map<graphState, MeroBUtil::SearchNode > NodeLookupTable;
+	typedef std::unordered_map<graphState, MeroBUtil::SearchNode > NodeLookupTable;
 
 	typedef OpenClosedList<MeroBUtil::SearchNode, MeroBUtil::SearchNodeHash,
 		MeroBUtil::SearchNodeEqual, MeroBUtil::GGreater> GQueue;

--- a/graphalgorithms/Propagation.h
+++ b/graphalgorithms/Propagation.h
@@ -16,7 +16,7 @@
 #include "SearchEnvironment.h"
 #include "GraphEnvironment.h"
 #include <deque>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "FPUtil.h"
 #include "OpenListB.h"
 
@@ -420,7 +420,7 @@ namespace PropUtil
 	typedef OpenListB<PropUtil::SearchNode, PropUtil::SearchNodeHash,
 		PropUtil::SearchNodeEqual, PropUtil::SearchNodeCompare, PropUtil::GGreater, PropUtil::FExtract> PQueue;
 
-	typedef __gnu_cxx::hash_map<graphState, PropUtil::SearchNode > NodeLookupTable;
+	typedef std::unordered_map<graphState, PropUtil::SearchNode > NodeLookupTable;
 
 	typedef OpenListB<PropUtil::SearchNode, PropUtil::SearchNodeHash,
 		PropUtil::SearchNodeEqual, PropUtil::GGreater, PropUtil::GGreater, PropUtil::FExtract> GQueue;

--- a/grids/CanonicalReach.cpp
+++ b/grids/CanonicalReach.cpp
@@ -87,7 +87,7 @@ void CanonicalReach::ComputeCanonicalReach(CanonicalGrid::xyLoc start)
 		me->GetSuccessors(d.data, neighbors);
 		bool foundParent = false;
 		// check if we have a neighbor that has this state as a parent
-		for (int x = 0; x < neighbors.size(); x++)
+		for (size_t x = 0; x < neighbors.size(); x++)
 		{
 			AStarOpenClosedDataWithF<CanonicalGrid::xyLoc> n;
 			if (search.GetClosedItem(neighbors[x], n))
@@ -127,5 +127,3 @@ bool CanonicalReach::ShouldNotGenerate(const xyLoc &start, const xyLoc &parent, 
 		return true;
 	return false;
 }
-
-

--- a/grids/Reach.cpp
+++ b/grids/Reach.cpp
@@ -90,7 +90,7 @@ void Reach::ComputeReach(xyLoc start)
 		me->GetSuccessors(d.data, neighbors);
 		bool foundParent = false;
 		// check if we have a neighbor that has this state as a parent
-		for (int x = 0; x < neighbors.size(); x++)
+		for (size_t x = 0; x < neighbors.size(); x++)
 		{
 			AStarOpenClosedDataWithF<xyLoc> n;
 			if (search.GetClosedItem(neighbors[x], n))
@@ -134,4 +134,3 @@ bool Reach::ShouldNotGenerate(const xyLoc &start, const xyLoc &parent, const xyL
 
 //Map *m;
 //std::vector<double> reach;
-

--- a/learning/FLRTAStar.h
+++ b/learning/FLRTAStar.h
@@ -15,7 +15,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include "vectorCache.h"
@@ -462,8 +462,8 @@ namespace FLRTA {
 		void OpenGLDraw() const {}
 		void OpenGLDraw(const environment *env) const;
 	private:
-		typedef __gnu_cxx::hash_map<uint64_t, learnedStateData<state>, Hash64 > LearnedStateData;
-		typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+		typedef std::unordered_map<uint64_t, learnedStateData<state>, Hash64 > LearnedStateData;
+		typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 		void ExtractBestPath(environment *env, const state &from, const state &to, std::vector<state> &thePath);
 		void MakeTrappedMove(environment *env, const state &from, std::vector<state> &thePath);
 		
@@ -966,11 +966,11 @@ namespace FLRTA {
 			dataLocation loc = (aoc.Lookup(m_pEnv->GetStateHash((*it).second.theState), node));
 			//if (loc != kOpenList) continue;
 
-			for (int x = 0; x < (*it).second.children->size(); x++)
+			for (size_t x = 0; x < (*it).second.children->size(); x++)
 			{
 				m_pEnv->GLDrawLine((*it).second.theState, (*it).second.children->at(x));
 			}
-			for (int x = 0; x < (*it).second.parents->size(); x++)
+			for (size_t x = 0; x < (*it).second.parents->size(); x++)
 			{
 				m_pEnv->GLDrawLine((*it).second.theState, (*it).second.parents->at(x));
 			}

--- a/learning/HLRTAStar.h
+++ b/learning/HLRTAStar.h
@@ -15,7 +15,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 
 namespace HLRTA{
 
@@ -104,7 +104,7 @@ public:
 	void OpenGLDraw() const {}
 	void OpenGLDraw(const environment *env) const;
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, learnedData<state>, Hash64 > LearnedHeuristic;
+	typedef std::unordered_map<uint64_t, learnedData<state>, Hash64 > LearnedHeuristic;
 
 	LearnedHeuristic heur;
 	state goal;

--- a/learning/HeuristicLearningMeasure.h
+++ b/learning/HeuristicLearningMeasure.h
@@ -11,7 +11,7 @@
 #define HEURISTICLEARNINGMEASURE_H
 
 #include "SearchEnvironment.h"
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include <iostream>
 #include <queue>
@@ -66,7 +66,7 @@ public:
 	
 	void ShowHistogram()
 	{
-		typedef __gnu_cxx::hash_map<double, sVal, HashDouble> HistogramData;
+		typedef std::unordered_map<double, sVal, HashDouble> HistogramData;
 		HistogramData histogram;
 		for (typename EnvironmentData::const_iterator it = learnData.begin(); it != learnData.end(); it++)
 		{
@@ -103,7 +103,7 @@ public:
 	}
 	
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, stateData<state>, Hash64 > EnvironmentData;
+	typedef std::unordered_map<uint64_t, stateData<state>, Hash64 > EnvironmentData;
 
 	double SumLearningRequired()
 	{

--- a/learning/LRTAStar.h
+++ b/learning/LRTAStar.h
@@ -16,7 +16,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 
 template <class state>
 struct learnedData {
@@ -64,7 +64,7 @@ public:
 	void OpenGLDraw() const {}
 	void OpenGLDraw(const environment *env) const;
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, learnedData<state>, Hash64 > LearnedHeuristic;
+	typedef std::unordered_map<uint64_t, learnedData<state>, Hash64 > LearnedHeuristic;
 
 	LearnedHeuristic heur;
 	state goal;

--- a/learning/LSSLRTAStar.h
+++ b/learning/LSSLRTAStar.h
@@ -14,7 +14,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include <queue>
@@ -128,8 +128,8 @@ public:
 	void OpenGLDraw() const {}
 	void OpenGLDraw(const environment *env) const;
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
-	typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+	typedef std::unordered_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
+	typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 	
 	environment *m_pEnv;
 	LearnedHeuristic heur;

--- a/learning/MPLRTAStar.h
+++ b/learning/MPLRTAStar.h
@@ -13,7 +13,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-//#include <ext/hash_map>
+//#include <unordered_map>
 #include <unordered_map>
 #include "Map2DEnvironment.h"
 

--- a/learning/daLRTAStar.h
+++ b/learning/daLRTAStar.h
@@ -13,7 +13,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include <queue>
@@ -109,8 +109,8 @@ namespace DALRTA {
 		void OpenGLDraw(const environment *env) const;
 	private:
 		typedef std::priority_queue<borderData<state>,std::vector<borderData<state> >,compareBorderData<state> > pQueue;
-		typedef __gnu_cxx::hash_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
-		typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+		typedef std::unordered_map<uint64_t, lssLearnedData<state>, Hash64 > LearnedHeuristic;
+		typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 		
 
 		bool ExpandLSS(environment *env, const state &from, const state &to, std::vector<state> &thePath);

--- a/learning/gLSSLRTAStar.h
+++ b/learning/gLSSLRTAStar.h
@@ -13,7 +13,7 @@
 #include "FPUtil.h"
 #include <deque>
 #include <vector>
-#include <ext/hash_map>
+#include <unordered_map>
 #include "TemplateAStar.h"
 #include "Timer.h"
 #include <queue>
@@ -160,8 +160,8 @@ public:
 	void OpenGLDraw() const {}
 	void OpenGLDraw(const environment *env) const;
 private:
-	typedef __gnu_cxx::hash_map<uint64_t, glssLearnedData<state>, Hash64 > LearnedHeuristic;
-	typedef __gnu_cxx::hash_map<uint64_t, bool, Hash64 > ClosedList;
+	typedef std::unordered_map<uint64_t, glssLearnedData<state>, Hash64 > LearnedHeuristic;
+	typedef std::unordered_map<uint64_t, bool, Hash64 > ClosedList;
 	
 	environment *m_pEnv;
 	LearnedHeuristic heur;

--- a/papers/DWA/Driver.cpp
+++ b/papers/DWA/Driver.cpp
@@ -185,7 +185,7 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 	
 	if (mode == kWaitPath && path.size() > 0)
 	{
-		for (int x = 1; x < path.size(); x++)
+		for (size_t x = 1; x < path.size(); x++)
 		{
 			float x1, y1, r1;
 			float x2, y2, r2;
@@ -210,7 +210,7 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 	}
 	if (0 && mode == kWaitPath && wpath.size() > 0)
 	{
-		for (int x = 1; x < wpath.size(); x++)
+		for (size_t x = 1; x < wpath.size(); x++)
 		{
 			float x1, y1, r1;
 			float x2, y2, r2;
@@ -399,7 +399,7 @@ uint64_t GetPathViaAbstraction(const xyLoc &start, const xyLoc &goal, std::vecto
 	// 3. Connect abstract regions
 	xyLoc currStart = start;
 //	astar.SetWeight(1.2);
-	for (int x = 1; x+1 < absPath.size(); x++)
+	for (size_t x = 1; x+1 < absPath.size(); x++)
 	{
 		xyLoc end = dwg->GetLocation(absPath[x]);
 		astar.GetPath(env, currStart, end, tmp);
@@ -420,13 +420,7 @@ void MyTestHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 {
 	srandom(20190529);
 	const int numProblems = 250;
-	uint64_t nbsNodes = 0;
 	uint64_t astarNodes = 0;
-	uint64_t wastarNodes = 0;
-	uint64_t wastarNodes2 = 0;
-	uint64_t wastarNodes3 = 0;
-	uint64_t absNodes = 0;
-	uint64_t firstAbsNodes = 0;
 	double optimalPath = 0;
 	double suboptimalPath = 0;
 	double suboptimalPath2 = 0;
@@ -604,5 +598,3 @@ bool MyClickHandler(unsigned long , int, int, point3d p, tButtonType , tMouseEve
 	
 	return true;
 }
-
-

--- a/papers/IBEX/Driver.cpp
+++ b/papers/IBEX/Driver.cpp
@@ -132,7 +132,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 
 		v = 5;
 		std::cout << s << std::endl;
-		for (int x = 0; x < moves.size(); x++)
+		for (size_t x = 0; x < moves.size(); x++)
 		{
 			std::cout << moves[x] << " ";
 		}

--- a/search/Heuristic.h
+++ b/search/Heuristic.h
@@ -9,6 +9,7 @@
 #ifndef hog2_glut_Heuristic_h
 #define hog2_glut_Heuristic_h
 
+#include <cstdint>
 #include <vector>
 
 enum HeuristicTreeNodeType {
@@ -81,14 +82,14 @@ double Heuristic<state>::HCost(const state &s1, const state &s2, int treeNode) c
 	{
 		case kMaxNode:
 		{
-			for (int x = 0; x < lookups[treeNode].numChildren; x++)
+			for (size_t x = 0; x < lookups[treeNode].numChildren; x++)
 			{
 				hval = std::max(hval, HCost(s1, s2, lookups[treeNode].whichNode+x));
 			}
 		} break;
 		case kAddNode:
 		{
-			for (int x = 0; x < lookups[treeNode].numChildren; x++)
+			for (size_t x = 0; x < lookups[treeNode].numChildren; x++)
 			{
 				hval += HCost(s1, s2, lookups[treeNode].whichNode+x);
 			}

--- a/search/LexPermutationPDB.h
+++ b/search/LexPermutationPDB.h
@@ -70,7 +70,7 @@ uint64_t LexPermutationPDB<state, action, environment, bits>::GetPDBHash(const s
 		if (s.puzzle[x] != -1)
 			dual[s.puzzle[x]] = x;
 	}
-	for (int x = 0; x < distinct.size(); x++)
+	for (size_t x = 0; x < distinct.size(); x++)
 	{
 		locs[x] = dual[distinct[x]];
 	}
@@ -107,7 +107,7 @@ void LexPermutationPDB<state, action, environment, bits>::GetStateFromPDBHash(ui
 		dual[x] = hashVal%numEntriesLeft;
 		hashVal /= numEntriesLeft;
 		numEntriesLeft++;
-		for (int y = x+1; y < distinct.size(); y++)
+		for (size_t y = x+1; y < distinct.size(); y++)
 		{
 			if (dual[y] >= dual[x])
 				dual[y]++;

--- a/search/MR1PermutationPDB.h
+++ b/search/MR1PermutationPDB.h
@@ -77,7 +77,7 @@ uint64_t MR1PermutationPDB<state, action, environment, bits>::GetPDBHash(const s
 			dual[s.puzzle[x]] = x;
 	}
 	// get locs by converting from the distinct array
-	for (int x = 0; x < distinct.size(); x++)
+	for (size_t x = 0; x < distinct.size(); x++)
 	{
 		locs[puzzleSize-x-1] = dual[distinct[distinct.size()-x-1]];
 		//dual[distinct[distinct.size()-x-1]] = -1;
@@ -122,7 +122,7 @@ void MR1PermutationPDB<state, action, environment, bits>::GetStateFromPDBHash(ui
 	//s.puzzle.resize(puzzleSize);
 	std::vector<int> &dual = dualCache[threadID];
 	dual.resize(puzzleSize); // vector for distinct item locations
-	for (int x = 0; x < dual.size(); x++)
+	for (size_t x = 0; x < dual.size(); x++)
 		dual[x] = x;
 	
 	size_t last = (puzzleSize-distinct.size());

--- a/search/PDBHeuristic.h
+++ b/search/PDBHeuristic.h
@@ -222,7 +222,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 			{
 				GetStateFromPDBHash(i, s);
 				env->GetActions(s, acts);
-				for (int y = 0; y < acts.size(); y++)
+				for (size_t y = 0; y < acts.size(); y++)
 				{
 					env->GetNextState(s, acts[y], u);
 					assert(env->InvertAction(acts[y]) == true);
@@ -500,12 +500,10 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	distribution.push_back(cnt);
 	
 	int depth = 0;
-	uint64_t newEntries;
 	bool searchForward = true;
 	std::vector<std::thread*> threads(numThreads);
 	printf("Creating %d threads\n", numThreads);
 	do {
-		newEntries = 0;
 		Timer s;
 		s.StartTimer();
 		for (int x = 0; x < numThreads; x++)
@@ -774,7 +772,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 					GetStateFromPDBHash(x, s, threadNum);
 					//std::cout << "Expanding[r][" << stateDepth << "]: " << s << std::endl;
 					env->GetActions(s, acts);
-					for (int y = 0; y < acts.size(); y++)
+					for (size_t y = 0; y < acts.size(); y++)
 					{
 						env->GetNextState(s, acts[y], t);
 						assert(env->InvertAction(acts[y]) == true);
@@ -824,7 +822,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 					GetStateFromPDBHash(x, s, threadNum);
 					//std::cout << "Expanding[r][" << stateDepth << "]: " << s << std::endl;
 					env->GetActions(s, acts);
-					for (int y = 0; y < acts.size(); y++)
+					for (size_t y = 0; y < acts.size(); y++)
 					{
 						env->GetNextState(s, acts[y], t);
 						//assert(env->InvertAction(acts[y]) == true);
@@ -1010,7 +1008,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 				//std::cout << "Expanding[r][" << stateDepth << "]: " << s << std::endl;
 				env->GetActions(s, acts);
 
-				for (int y = 0; y < acts.size(); y++)
+				for (size_t y = 0; y < acts.size(); y++)
 				{
 					env->GetNextState(s, acts[y], t);
 					assert(env->InvertAction(acts[y]) == true);
@@ -1046,7 +1044,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 				GetStateFromPDBHash(i, s, threadNum);
 				env->GetActions(s, acts);
 				
-				for (int y = 0; y < acts.size(); y++)
+				for (size_t y = 0; y < acts.size(); y++)
 				{
 					env->GetNextState(s, acts[y], t);
 					assert(env->InvertAction(acts[y]) == true);
@@ -1118,7 +1116,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 {
 	abstractState s;
 	state s1;
-	for (int x = 0; x < PDB.Size(); x++)
+	for (size_t x = 0; x < PDB.Size(); x++)
 	{
 		GetStateFromPDBHash(x, s);
 		s1 = GetStateFromAbstractState(s);
@@ -1183,7 +1181,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	if (print_histogram)
 	{
 		printf("Setting boundaries [%d values]: ", (1<<numBits));
-		for (int x = 0; x < cutoffs.size(); x++)
+		for (size_t x = 0; x < cutoffs.size(); x++)
 			printf("%d ", cutoffs[x]);
 		printf("\n");
 	}
@@ -1191,7 +1189,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	
 	for (uint64_t x = 0; x < PDB.Size(); x++)
 	{
-		for (int y = 0; y < cutoffs.size(); y++)
+		for (size_t y = 0; y < cutoffs.size(); y++)
 		{
 			if (PDB.Get(x) >= cutoffs[y] && PDB.Get(x) < cutoffs[y+1])
 			{
@@ -1385,7 +1383,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	if (print_histogram)
 	{
 		printf("Setting boundaries [%d values]: ", (1<<4));
-		for (int x = 0; x < cutoffs.size(); x++)
+		for (size_t x = 0; x < cutoffs.size(); x++)
 			printf("%d ", cutoffs[x]);
 		printf("\n");
 	}
@@ -1400,13 +1398,13 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 		printf("Unknown PDB type: %d\n", type);
 	}
 
-	for (int x = 0; x < cutoffs.size(); x++)
+	for (size_t x = 0; x < cutoffs.size(); x++)
 		newPDB->vrcValues[x] = cutoffs[x];
 	newPDB->PDB.Resize(PDB.Size());
 	cutoffs.push_back(256);
 	for (uint64_t x = 0; x < PDB.Size(); x++)
 	{
-		for (int y = 0; y < cutoffs.size(); y++)
+		for (size_t y = 0; y < cutoffs.size(); y++)
 		{
 			if (PDB.Get(x) >= cutoffs[y] && PDB.Get(x) < cutoffs[y+1])
 			{
@@ -1431,7 +1429,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	if (print_histogram)
 	{
 		printf("Setting boundaries [%d values]: ", (1<<4));
-		for (int x = 0; x < cutoffs.size(); x++)
+		for (size_t x = 0; x < cutoffs.size(); x++)
 			printf("%d ", cutoffs[x]);
 		printf("\n");
 	}
@@ -1452,7 +1450,7 @@ void PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, pdb
 	cutoffs.push_back(256);
 	for (uint64_t x = 0; x < PDB.Size(); x++)
 	{
-		for (int y = 0; y < cutoffs.size(); y++)
+		for (size_t y = 0; y < cutoffs.size(); y++)
 		{
 			if (PDB.Get(x) >= cutoffs[y] && PDB.Get(x) < cutoffs[y+1])
 			{
@@ -1532,7 +1530,7 @@ double PDBHeuristic<abstractState, abstractAction, abstractEnvironment, state, p
 			average += PDB.Get(x);
 		}
 	}
-	for (int x = 0; x < histogram.size(); x++)
+	for (size_t x = 0; x < histogram.size(); x++)
 	{
 		if (histogram[x] > 0)
 			printf("%d: %llu\n", x, histogram[x]);

--- a/search/PermutationPDB.h
+++ b/search/PermutationPDB.h
@@ -71,14 +71,14 @@ std::string PermutationPDB<state, action, environment, bits>::GetFileName(const 
 		fileName+='/';
 	fileName += PDBHeuristic<state, action, environment, state, bits>::env->GetName();
 	fileName += "-";
-	for (int x = 0; x < PDBHeuristic<state, action, environment, state, bits>::goalState.size(); x++)
+	for (size_t x = 0; x < PDBHeuristic<state, action, environment, state, bits>::goalState.size(); x++)
 	{
 		fileName += std::to_string(PDBHeuristic<state, action, environment, state, bits>::goalState[0].puzzle[x]);
 		fileName += ";";
 	}
 	fileName.pop_back(); // remove colon
 	fileName += "-";
-	for (int x = 0; x < distinct.size(); x++)
+	for (size_t x = 0; x < distinct.size(); x++)
 	{
 		fileName += std::to_string(distinct[x]);
 		fileName += ";";

--- a/search/SearchEnvironment.h
+++ b/search/SearchEnvironment.h
@@ -121,7 +121,7 @@ action SearchEnvironment<state,action>::GetAction(const state &s1, const state &
 {
 	std::vector<action> a;
 	GetActions(s1, a);
-	for (int x = 0; x < a.size(); x++)
+	for (size_t x = 0; x < a.size(); x++)
 	{
 		state s = s1;
 		ApplyAction(s, a[x]);

--- a/utils/BitMap.cpp
+++ b/utils/BitMap.cpp
@@ -74,7 +74,7 @@ BitMapPic::BitMapPic(const char* file)
 					
 					if (header.biBitCount == 32)
 					{
-						for (int x = 0; x < height; x++)
+						for (size_t x = 0; x < height; x++)
 						{
 							if (reverseHeight)
 								fread(&image[(height-x-1)*width*4], sizeof(char), width*4, f);

--- a/utils/BitVector.cpp
+++ b/utils/BitVector.cpp
@@ -21,7 +21,7 @@ BitVector::BitVector(uint64_t _size)
 	true_size = _size;
 	size = (_size>>storageBitsPower)+1;
 	storage = new storageElement[size];
-	for (int x = 0; x < size; x++)
+	for (size_t x = 0; x < size; x++)
 		storage[x] = 0;
 	memmap = false;
 }
@@ -135,7 +135,7 @@ void BitVector::Set(uint64_t index, bool value)
 bool BitVector::Equals(BitVector *bv)
 {
 	if (bv->size != size) return false;
-	for (int x = 0; x < size; x++)
+	for (size_t x = 0; x < size; x++)
 		if (storage[x] != bv->storage[x])
 			return false;
 	return true;
@@ -144,7 +144,7 @@ bool BitVector::Equals(BitVector *bv)
 uint64_t BitVector::GetNumSetBits()
 {
 	uint64_t sum = 0;
-	for (int x = 0; x < size; x++)
+	for (size_t x = 0; x < size; x++)
 	{
 		storageElement iter = storage[x];
 		while (iter) {

--- a/utils/GLUtil.cpp
+++ b/utils/GLUtil.cpp
@@ -532,7 +532,7 @@ void DrawText(double x, double y, double z, double scale, const char *str)
 	glRotatef(180, 0.0, 0.0, 1.0);
 	glRotatef(180, 0.0, 1.0, 0.0);
 	glDisable(GL_LIGHTING);
-	for (int which = 0; which < strlen(str); which++)
+	for (size_t which = 0; which < strlen(str); which++)
 		glutStrokeCharacter(GLUT_STROKE_ROMAN, str[which]);
 //	glEnable(GL_LIGHTING);
 	//glTranslatef(-x/width+0.5, -y/height+0.5, 0);
@@ -544,7 +544,7 @@ void DrawTextCentered(double x, double y, double z, double scale, const char *st
 	glPushMatrix();
 	
 	int width = 0;
-	for (int which = 0; which < strlen(str); which++)
+	for (size_t which = 0; which < strlen(str); which++)
 		width += glutStrokeWidth(GLUT_STROKE_ROMAN, str[which]);
 	
 	glTranslatef(x, y, z);
@@ -554,7 +554,7 @@ void DrawTextCentered(double x, double y, double z, double scale, const char *st
 	glDisable(GL_LIGHTING);
 	glTranslatef(-width/2, -4.0/scale, 0);
 	
-	for (int which = 0; which < strlen(str); which++)
+	for (size_t which = 0; which < strlen(str); which++)
 		glutStrokeCharacter(GLUT_STROKE_ROMAN, str[which]);
 
 //	glEnable(GL_LIGHTING);

--- a/utils/SVGUtil.cpp
+++ b/utils/SVGUtil.cpp
@@ -179,7 +179,7 @@ std::string SVGDrawLineSegments(const std::vector<Graphics::point> &lines, float
 
 	s += "M "+std::to_string(lines[0].x)+" "+std::to_string(lines[0].y)+" L";
 	
-	for (int x = 1; x < lines.size(); x++)
+	for (size_t x = 1; x < lines.size(); x++)
 	{
 		s += " "+std::to_string(lines[x].x)+" "+std::to_string(lines[x].y)+" ";
 	}
@@ -293,7 +293,7 @@ void PointToSVG(Graphics::point &p, float xmultiplier, float ymultiplier)
 
 void HandleCommand(const std::vector<Graphics::Display::data> &drawCommands, std::string &s, int width, int height, int viewport)
 {
-	for (int x = 0; x < drawCommands.size(); x++)
+	for (size_t x = 0; x < drawCommands.size(); x++)
 	{
 		if (drawCommands[x].viewport != viewport)
 			continue;
@@ -466,7 +466,7 @@ std::string MakeSVG(const Graphics::Display &disp, int width, int height, int vi
 	HandleCommand(disp.backgroundDrawCommands, s, width, height, viewport);
 	HandleCommand(disp.drawCommands, s, width, height, viewport);
 
-	for (int x = 0; x < disp.text.size(); x++)
+	for (size_t x = 0; x < disp.text.size(); x++)
 	{
 		const auto &i = disp.text[x];
 		if (i.viewport == viewport)
@@ -487,7 +487,7 @@ std::string MakeSVG(const Graphics::Display &disp, int width, int height, int vi
 		}
 	}
 	static std::vector<Graphics::point> outputPoints;
-	for (int x = 0; x < disp.lineSegments.size(); x++)
+	for (size_t x = 0; x < disp.lineSegments.size(); x++)
 	{
 		const auto &i = disp.lineSegments[x];
 		if (i.viewport == viewport)
@@ -513,6 +513,3 @@ std::string MakeSVG(const Graphics::Display &disp, int width, int height, int vi
 	s += "</svg>";
 	return s;
 }
-
-
-


### PR DESCRIPTION
Compiling with GCC 10.3.0 reveals a very large number of compilation warnings.

This PR fixes some of them, primarily by switching from the long-deprecated `ext/hash_map` to the now-standard `unordered_map` and fixing loop iteration variable types.