### PR TITLE
Changed openLoc to index KeyChanged call in Remove

### DIFF
--- a/algorithms/AStarOpenClosed.h
+++ b/algorithms/AStarOpenClosed.h
@@ -242,7 +242,7 @@ void AStarOpenClosed<state, CmpKey, dataStructure>::Remove(uint64_t hash)
 	theHeap[openLoc] = theHeap.back();
 	theHeap.pop_back();
 	elements[swappedItem].openLocation = openLoc;
-	KeyChanged(openLoc);
+	KeyChanged(index);
 }
 
 /**


### PR DESCRIPTION
In Remove() there are two index variables (amongst others variables):
- **index** which is the index of the given element in the element list.
- **openLoc** which is the index of said element in the heap.

The function KeyChanged() expects the index of the element whose key was changed.
Remove() calls KeyChanged(), but calls it with openLoc instead of index, which is what should be sent.
Therefore, I changed the call to use index instead of openLoc.