### PR TITLE
Added real field default initialization to pancake evironment

### DIFF
--- a/environments/PancakePuzzle.h
+++ b/environments/PancakePuzzle.h
@@ -157,7 +157,7 @@ public:
 	void SetUseRealValueEdges(bool use) { real = use; }
 	bool pruneActions;
 private:
-	bool real;
+	bool real = false;
 	std::vector<PancakePuzzleAction> operators;
 	mutable std::vector<PancakePuzzleAction> actCache;
 	bool goal_stored; // whether a goal is stored or not


### PR DESCRIPTION
In the pancake environment there is a real field. If left uninitialized, it can lead to problems when compiling in release mode and trying to calculate a path length.
For example, take the following Pancake-14 instance: 2 9 13 6 3 4 10 8 5 11 7 1 12 0
```cpp
PancakePuzzleState<N> start; // The aforementioned state
PancakePuzzleState<N> goal; // Canonical goal
TemplateAStar<PancakePuzzleState<N>,PancakePuzzleAction,PancakePuzzle<N>> astar;
astar.GetPath(&env, start, goal, solutionPath);
printf("solution %1.0f;\n", env.GetPathLength(solutionPath));
```
will print 14, despite 14 states in the solution path (including the start), and overall cost of 13 as 13 actions are needed.
