### PR TITLE
Added .gitattributes to fix #84

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.h linguist-language=C++
+*.inc linguist-language=Makefile
+
+build/XCode/**/*.h linguist-language=Objective-C
+
+maps/** linguist-detectable=false
+scenarios/** linguist-detectable=false


### PR DESCRIPTION
This fixes #84.
We now ignore the maps and scenarios folders, mark all .h files as C++ except those under build/XCode, and make all .inc files Makefile.