### PR TITLE
Internalized buttons for 8 demos

### DIFF
--- a/build/SFML/Makefile
+++ b/build/SFML/Makefile
@@ -57,6 +57,18 @@ PROJECTS = \
   demos/bidir \
   demos/multiTarget \
   demos/rc \
+  demos/astar-map \
+  demos/suboptimal-map \
+  demos/STP \
+  demos/transit-routing-maps \
+  demos/gridabstraction \
+  demos/JPS \
+  demos/bb \
+  demos/reach \
+  demos/dh-place \
+  demos/bidirnecessary \
+  demos/GMX \
+  demos/inconsistency-graph \
   papers/IBEX \
   papers/DWA \
   papers/BGS \
@@ -116,8 +128,25 @@ PROJECTS_ALL = \
   demos/DFID \
   demos/dijkstra \
   demos/astar \
-  demos/bidir \
   demos/idastar \
+  demos/fastmap \
+  demos/pancake \
+  demos/racetrack \
+  demos/bidir \
+  demos/multiTarget \
+  demos/rc \
+  demos/astar-map \
+  demos/suboptimal-map \
+  demos/STP \
+  demos/transit-routing-maps \
+  demos/gridabstraction \
+  demos/JPS \
+  demos/bb \
+  demos/reach \
+  demos/dh-place \
+  demos/bidirnecessary \
+  demos/GMX \
+  demos/inconsistency-graph \
   apps/snakebird \
   papers/DSDWA \
 #  papers/IBEX \

--- a/build/SFML/demos/GMX/Makefile
+++ b/build/SFML/demos/GMX/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/GMX/Makefile.prj.inc
+++ b/build/SFML/demos/GMX/Makefile.prj.inc
@@ -1,0 +1,59 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = GMX
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search 
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/GMX/Driver.cpp 

--- a/build/SFML/demos/JPS/Makefile
+++ b/build/SFML/demos/JPS/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/JPS/Makefile.prj.inc
+++ b/build/SFML/demos/JPS/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = JPS
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libgrids.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libgrids.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/JPS/Driver.cpp 

--- a/build/SFML/demos/STP/Makefile
+++ b/build/SFML/demos/STP/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/STP/Makefile.prj.inc
+++ b/build/SFML/demos/STP/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = stp
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/envutil
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lenvutil
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lenvutil
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a \
+  $(DBG_BINDIR)/libenvutil.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a \
+  $(REL_BINDIR)/libenvutil.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/STP/Driver.cpp 

--- a/build/SFML/demos/astar-map/Makefile
+++ b/build/SFML/demos/astar-map/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/astar-map/Makefile.prj.inc
+++ b/build/SFML/demos/astar-map/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = astar-map
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids 
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lgrids
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lgrids
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a \
+  $(DBG_BINDIR)/libgrids.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a \
+  $(REL_BINDIR)/libgrids.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/astar-map/Driver.cpp \

--- a/build/SFML/demos/bb/Makefile
+++ b/build/SFML/demos/bb/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/bb/Makefile.prj.inc
+++ b/build/SFML/demos/bb/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = bb
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms  -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libgrids.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libgrids.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/bb/Driver.cpp 

--- a/build/SFML/demos/bidirnecessary/Makefile
+++ b/build/SFML/demos/bidirnecessary/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/bidirnecessary/Makefile.prj.inc
+++ b/build/SFML/demos/bidirnecessary/Makefile.prj.inc
@@ -1,0 +1,59 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = bidirnecessary
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search 
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/bidirnecessary/Driver.cpp 

--- a/build/SFML/demos/dh-place/Makefile
+++ b/build/SFML/demos/dh-place/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/dh-place/Makefile.prj.inc
+++ b/build/SFML/demos/dh-place/Makefile.prj.inc
@@ -1,0 +1,59 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = dh-place
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search 
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/dh-place/Driver.cpp 

--- a/build/SFML/demos/gridabstraction/Makefile
+++ b/build/SFML/demos/gridabstraction/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/gridabstraction/Makefile.prj.inc
+++ b/build/SFML/demos/gridabstraction/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = gridabstraction
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libgrids.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libgrids.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/gridabstraction/Driver.cpp 

--- a/build/SFML/demos/inconsistency-graph/Makefile
+++ b/build/SFML/demos/inconsistency-graph/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/inconsistency-graph/Makefile.prj.inc
+++ b/build/SFML/demos/inconsistency-graph/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = inconsistency
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search -I$(ROOT)/envutil
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lenvutil
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils -lenvutil
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a \
+  $(DBG_BINDIR)/libenvutil.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a \
+  $(REL_BINDIR)/libenvutil.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/inconsistency-graph/Driver.cpp 

--- a/build/SFML/demos/reach/Makefile
+++ b/build/SFML/demos/reach/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/reach/Makefile.prj.inc
+++ b/build/SFML/demos/reach/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = reach
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libgrids.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libgrids.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/reach/Driver.cpp 

--- a/build/SFML/demos/suboptimal-map/Makefile
+++ b/build/SFML/demos/suboptimal-map/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/suboptimal-map/Makefile.prj.inc
+++ b/build/SFML/demos/suboptimal-map/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = suboptimal-map
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/envutil -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search 
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lenvutil -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+PROJ_REL_LIB = -lenvironments -lenvutil -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libenvutil.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libenvutil.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/suboptimal-map/Driver.cpp 

--- a/build/SFML/demos/transit-routing-maps/Makefile
+++ b/build/SFML/demos/transit-routing-maps/Makefile
@@ -1,0 +1,3 @@
+include Makefile.prj.inc
+include ../../Makefile.com.inc
+include ../../Makefile.exe.inc

--- a/build/SFML/demos/transit-routing-maps/Makefile.prj.inc
+++ b/build/SFML/demos/transit-routing-maps/Makefile.prj.inc
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# GNU Makefile for static libraries: project dependent part
+#
+# $Id: Makefile.prj.inc,v 1.2 2006/10/20 20:20:15 emarkus Exp $
+# $Source: /usr/cvsroot/project_hog/build/gmake/apps/sample/Makefile.prj.inc,v $
+#-----------------------------------------------------------------------------
+
+NAME = transit
+DBG_NAME = $(NAME)
+REL_NAME = $(NAME)
+
+ROOT = ../../../..
+VPATH = $(ROOT)
+
+DBG_OBJDIR = $(ROOT)/objs/$(NAME)/debug
+REL_OBJDIR = $(ROOT)/objs/$(NAME)/release
+DBG_BINDIR = $(ROOT)/bin/debug
+REL_BINDIR = $(ROOT)/bin/release
+
+PROJ_CXXFLAGS = -I$(ROOT)/absmapalgorithms -I$(ROOT)/graphalgorithms -I$(ROOT)/gui -I$(ROOT)/simulation -I$(ROOT)/environments -I$(ROOT)/mapalgorithms -I$(ROOT)/algorithms -I$(ROOT)/generic -I$(ROOT)/utils -I$(ROOT)/graph -I$(ROOT)/search  -I$(ROOT)/grids
+
+PROJ_DBG_CXXFLAGS = $(PROJ_CXXFLAGS)
+PROJ_REL_CXXFLAGS = $(PROJ_CXXFLAGS)
+
+PROJ_DBG_LNFLAGS = -L$(DBG_BINDIR)
+PROJ_REL_LNFLAGS = -L$(REL_BINDIR)
+
+PROJ_DBG_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+PROJ_REL_LIB = -lenvironments -lmapalgorithms -lalgorithms -lgraphalgorithms -lgui -lgraph -lgrids -lutils
+
+PROJ_DBG_DEP = \
+  $(DBG_BINDIR)/libutils.a \
+  $(DBG_BINDIR)/libgraph.a \
+  $(DBG_BINDIR)/libgui.a \
+  $(DBG_BINDIR)/libgrids.a \
+  $(DBG_BINDIR)/libenvironments.a \
+  $(DBG_BINDIR)/libmapalgorithms.a \
+  $(DBG_BINDIR)/libgraphalgorithms.a \
+  $(DBG_BINDIR)/libalgorithms.a
+
+PROJ_REL_DEP = \
+  $(REL_BINDIR)/libutils.a \
+  $(REL_BINDIR)/libgraph.a \
+  $(REL_BINDIR)/libgui.a \
+  $(REL_BINDIR)/libgrids.a \
+  $(REL_BINDIR)/libenvironments.a \
+  $(REL_BINDIR)/libmapalgorithms.a \
+  $(REL_BINDIR)/libgraphalgorithms.a \
+  $(REL_BINDIR)/libalgorithms.a
+
+ifeq ("$(OPENGL)", "STUB")
+PROJ_DBG_LIB += -lSTUB
+PROJ_REL_LIB += -lSTUB
+PROJ_DBG_DEP +=   $(DBG_BINDIR)/libSTUB.a
+PROJ_REL_DEP +=   $(REL_BINDIR)/libSTUB.a
+endif
+
+default : all
+
+SRC_CPP = \
+	demos/transit-routing-maps/Driver.cpp 

--- a/build/SFML/environments/Makefile.prj.inc
+++ b/build/SFML/environments/Makefile.prj.inc
@@ -44,6 +44,7 @@ SRC_CPP = \
 	environments/Map3DGrid.cpp \
 	environments/Map2DHeading.cpp \
 	environments/MinimalSectorAbstraction.cpp \
+	environments/Map2DSectorAbstractionEnvironment.cpp \
 	environments/MNAgentPuzzle.cpp \
 	environments/RC.cpp \
 	environments/RubiksCubeEdges.cpp \

--- a/demos/DFID/Driver.cpp
+++ b/demos/DFID/Driver.cpp
@@ -26,6 +26,25 @@ bool running = false;
 
 int drawMode = 2; // bit 0 [dfid] bit 1 [dfs] bit 2 [bfs]
 
+std::vector<int> buttons;
+typedef enum : int {
+	kRunButton = 0,
+	kPauseButton = 1,
+	kDFSButton = 2,
+	kDFIDButton = 3,
+	kBFSButton = 4,
+	kBF2Button = 5,
+	kBF3Button = 6,
+	kBF4Button = 7,
+	kBF5Button = 8,
+	kBF6Button = 9,
+	kBF7Button = 10,
+	kBF8Button = 11,
+	kBF9Button = 12,
+} buttonID;
+void ActivateBFButton(buttonID bId);
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
@@ -69,9 +88,13 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 	{
 		printf("Window %ld created\n", windowID);
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
-		SetNumPorts(windowID, 1);
+		SetNumPorts(windowID, 2);
 //		ReinitViewports(windowID, Graphics::rect{-1.f, -1.f, 1.f, 1.f}, kScaleToFill);
-		ReinitViewports(windowID, Graphics::rect{-1.f, -1.f, 1.f, 1.f}, kScaleToSquare);
+		// Bottom part of screen (for buttons)
+		ReinitViewports(windowID, {-1, 0, 1, 1}, kScaleToSquare);
+		// Top part of screen (overlapping, but on top -> allows for larger text size for button viewport)
+		AddViewport(windowID, {-1, -1, 1, 0.5f}, kScaleToSquare);
+		SetupGUI(windowID);
 		
 		{
 			char txt[] = "Algorithms: ";
@@ -107,9 +130,8 @@ NaryState goal = tree.GetLastNode();
 
 int frameCnt = 0;
 
-void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+void DrawSim(Graphics::Display &display, unsigned long windowID, unsigned int viewport)
 {
-	Graphics::Display &display = getCurrentContext()->display;
 	display.FillRect({-1.5, -1.0, 1.5, 1}, Colors::white);
 	tree.SetColor(Colors::black);
 	if (running)
@@ -142,7 +164,121 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 		frameCnt++;
 	}
 	return;
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 1.4f;
+	const float borderPaddingY = 0.2f;
+	const float verticalSep = 0.1f;
+	const float buttonHeight = 0.1f;
+
+	// Basic controls
+	float horizontalSep = 0.1f;
+	float buttonWidth = 0.4f;
+	float top = 0+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect controlButton({-2.25f+borderPaddingX, top, -2.25f+borderPaddingX+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 0, controlButton, "Run", 'r', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	controlButton.r += offsetRect;
+	b = CreateButton(windowID, 0, controlButton, "Pause", 'p', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Choose search algorithm
+	horizontalSep = 0.1f;
+	buttonWidth = 0.4f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	Graphics::roundedRect algButton({-2.25f+borderPaddingX, top, -2.25f+borderPaddingX+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 0, algButton, "DFS", 'd', 0.01f, Colors::black, Colors::black,
+					 Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 0, algButton, "DFID", 'i', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 0, algButton, "BFS", 'b', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+
+	// Choose branching factor
+	horizontalSep = 0.1f;
+	buttonWidth = 0.15f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect bfButton({-2.25f+borderPaddingX, top, -2.25f+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 0, bfButton, "2", '2', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "3", '3', 0.01f, Colors::black, Colors::black,
+					 Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "4", '4', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "5", '5', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "6", '6', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "7", '7', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "8", '8', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+	b = CreateButton(windowID, 0, bfButton, "9", '9', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	bfButton.r += offsetRect;
+}
+
+void ActivateBFButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kBF2Button], bId == kBF2Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF3Button], bId == kBF3Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF4Button], bId == kBF4Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF5Button], bId == kBF5Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF6Button], bId == kBF6Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF7Button], bId == kBF7Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF8Button], bId == kBF8Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBF9Button], bId == kBF9Button ? Colors::yellow : Colors::white);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-2.25f, 0, 2.25f, 1}, Colors::darkgray);
+	display.FillRect({-2.25f+e, 0+e, 2.25f-e, 1-e}, Colors::lightgray);
+	display.DrawText("Control: ", {-2.25f+0.1f, 0.2f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Search Algorithm: ", {-2.25f+0.1f, 0.4f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Branching Factor: ", {-2.25f+0.1f, 0.6f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+{
+	Graphics::Display &display = getCurrentContext()->display;
 	
+	if (viewport == 0)
+		DrawGUI(display);
+	else
+		DrawSim(display, windowID, viewport);
 }
 
 int MyCLHandler(char *argument[], int maxNumArgs)
@@ -164,6 +300,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			SetButtonFillColor(buttons[kDFIDButton], drawMode&0x1 ? Colors::yellow : Colors::white);
 			break;
 		}
 		case 'd':
@@ -173,6 +310,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			SetButtonFillColor(buttons[kDFSButton], drawMode&0x2 ? Colors::yellow : Colors::white);
 			break;
 		}
 		case 'b':
@@ -182,6 +320,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			SetButtonFillColor(buttons[kBFSButton], drawMode&0x4 ? Colors::yellow : Colors::white);
 			break;
 		}
 		case '{':
@@ -216,6 +355,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case 'r':
 //			recording = !recording; running = true;
+			running = true;
 			break;
 		case '0':
 		{
@@ -233,6 +373,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF2Button);
 			break;
 		}
 		case '3':
@@ -243,6 +384,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF3Button);
 			break;
 		}
 		case '4':
@@ -253,6 +395,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF4Button);
 			break;
 		}
 		case '5':
@@ -263,6 +406,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF5Button);
 			break;
 		}
 		case '6':
@@ -273,6 +417,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF6Button);
 			break;
 		}
 		case '7':
@@ -283,6 +428,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF7Button);
 			break;
 		}
 		case '8':
@@ -293,6 +439,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF8Button);
 			break;
 		}
 		case '9':
@@ -303,6 +450,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			dfid.Reset();
 			dfs.Reset();
 			bfs.Reset();
+			ActivateBFButton(kBF9Button);
 			break;
 		}
 			break;
@@ -344,8 +492,12 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 }
 
 
-bool MyClickHandler(unsigned long , int x, int y, point3d loc, tButtonType , tMouseEventType e)
+bool MyClickHandler(unsigned long , int viewport, int x, int y, point3d loc, tButtonType , tMouseEventType e)
 {
+	// Prevent button clicks from affecting simulation.
+	if (viewport == 0)
+		return false;
+
 	if (e == kMouseDown)
 	{
 		goal = tree.GetClosestNode(loc.x, loc.y);

--- a/demos/DFID/Driver.h
+++ b/demos/DFID/Driver.h
@@ -13,5 +13,5 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType);
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *data);
 void MyDisplayHandler(unsigned long windowID, tKeyboardModifier, char key);
 int MyCLHandler(char *argument[], int maxNumArgs);
-bool MyClickHandler(unsigned long windowID, int x, int y, point3d loc, tButtonType, tMouseEventType);
+bool MyClickHandler(unsigned long windowID, int viewport, int x, int y, point3d loc, tButtonType, tMouseEventType);
 void InstallHandlers();

--- a/demos/JPS/Driver.cpp
+++ b/demos/JPS/Driver.cpp
@@ -51,6 +51,24 @@ bool mapChange = true;
 
 int stepsPerFrame = 1;
 
+std::vector<int> buttons;
+typedef enum : int {
+	kBasicButton = 0,
+	kFullButton = 1,
+	kBasicJPButton = 2,
+	kAStarButton = 3,
+	kCAStarButton = 4,
+	kJPSButton = 5,
+	kBJPS4Button = 6,
+	kCDijkstraButton = 7,
+	kFasterButton = 8,
+	kSlowerButton = 9,
+	kPauseButton = 10,
+	kStepButton = 11,
+} buttonID;
+void ActivateModeButton(buttonID bId);
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
@@ -91,8 +109,12 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		printf("Window %ld created\n", windowID);
 		//glClearColor(0.99, 0.99, 0.99, 1.0);
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
-		SetNumPorts(windowID, 1);
-		ReinitViewports(windowID, {-1, -1, 1, 1}, kScaleToSquare);
+		SetNumPorts(windowID, 2);
+		// Left half of screen
+		ReinitViewports(windowID, {-1, -1, 0, 1}, kScaleToSquare);
+		// Right half of screen (buttons)
+		AddViewport(windowID, {0, -1, 1, 1}, kScaleToSquare);
+		SetupGUI(windowID);
 
 		Map *map = new Map(1,1);
 		LoadMap(map);
@@ -105,10 +127,8 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 
 int frameCnt = 0;
 
-void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+void DrawSim(Graphics::Display &display)
 {
-	Graphics::Display &display = getCurrentContext()->display;
-	
 	if (mapChange == true)
 	{
 		display.StartBackground();
@@ -210,6 +230,129 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 //	if (m == kBasicCanonical || m == kFullCanonical || m == kBasicCanonicalJumpPoint)
 //		else if (m != kCanonicalDijkstra)
 //	}
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 0.1f;
+	const float borderPaddingY = 0.35f;
+	const float verticalSep = 0.25f;
+	const float buttonHeight = 0.1f;
+
+	// Choosing canonical ordering
+	float horizontalSep = 0.2f;
+	float buttonWidth = 0.6f;
+	float top = -1+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect coButton({-1+0.3f, top, -1+0.3f+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 1, coButton, "Basic", 'b', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	coButton.r += offsetRect;
+	b = CreateButton(windowID, 1, coButton, "Full", 'f', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	buttonWidth = 1.1f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect coBothButton({-1+0.45f, top, -1+0.45f+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, coBothButton, "Basic And Jump Points", 'j', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Choosing algorithm
+	horizontalSep = 0.075f;
+	buttonWidth = 0.55f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect algButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, algButton, "A*", '5', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 1, algButton, "Canonical A*", '1', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 1, algButton, "JPS", '3', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	horizontalSep = 0.1f;
+	buttonWidth = 0.85f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect alg2Button({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, alg2Button, "Bounded JPS(4)", '2', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	alg2Button.r += offsetRect;
+	b = CreateButton(windowID, 1, alg2Button, "Canonical Dijkstra", '4', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Simulation settings
+	horizontalSep = 0.2f;
+	buttonWidth = 0.6f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect speedButton({-1+0.3f, top, -1+0.3f+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, speedButton, "Run Faster", ']', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	speedButton.r += offsetRect;
+	b = CreateButton(windowID, 1, speedButton, "Run Slower", '[', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect simButton({-1+0.3f, top, -1+0.3f+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, simButton, "Pause", '0', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	simButton.r += offsetRect;
+	b = CreateButton(windowID, 1, simButton, "Step", 'o', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-1, -1, 1, 1}, Colors::darkgray);
+	display.FillRect({-1+e, -1+e, 1-e, 1-e}, Colors::lightgray);
+	display.DrawText("Canonical Orderings: ", {-1+0.1f, -0.8f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Algorithms: ", {-1+0.1f, -0.25f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Algorithm Control: ", {-1+0.1f, 0.3f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void ActivateModeButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kBasicButton], bId == kBasicButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBasicJPButton], bId == kBasicJPButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kFullButton], bId == kFullButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kAStarButton], bId == kAStarButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kCAStarButton], bId == kCAStarButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kBJPS4Button], bId == kBJPS4Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kJPSButton], bId == kJPSButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kCDijkstraButton], bId == kCDijkstraButton ? Colors::yellow : Colors::white);
+}
+
+void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+{
+	Graphics::Display &display = getCurrentContext()->display;
+	if (viewport == 0)
+		DrawSim(display);
+	else
+		DrawGUI(display);
+	
 //	if (recording && viewport == GetNumPorts(windowID)-1)
 //	{
 //		char fname[255];
@@ -281,6 +424,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case '1':
 			m = kCanonicalAStar;
+			ActivateModeButton(kCAStarButton);
 			submitTextToBuffer("Running Canonical A*");
 			jpsPath.resize(0);
 			if (running)
@@ -293,6 +437,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case '2':
 			m = kBoundedJPS;
+			ActivateModeButton(kBJPS4Button);
 			submitTextToBuffer("Running Bounded JPS(4)");
 			jpsPath.resize(0);
 			if (running)
@@ -305,6 +450,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case '3':
 			m = kJPS;
+			ActivateModeButton(kJPSButton);
 			submitTextToBuffer("Running JPS");
 			jpsPath.resize(0);
 			if (running)
@@ -317,6 +463,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case '4':
 			m = kCanonicalDijkstra;
+			ActivateModeButton(kCDijkstraButton);
 			submitTextToBuffer("Running Canonical Dijkstra");
 			dijPath.resize(0);
 			if (running)
@@ -329,6 +476,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case '5':
 			m = kAStar;
+			ActivateModeButton(kAStarButton);
 			submitTextToBuffer("Running (classic) A*");
 			astarPath.resize(0);
 			if (running)
@@ -358,14 +506,17 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 		case 'b':
 			submitTextToBuffer("Click/drag to show basic canonical ordering");
 			m = kBasicCanonical;
+			ActivateModeButton(kBasicButton);
 			break;
 		case 'j':
 			submitTextToBuffer("Click/drag to show basic canonical ordering with jump points");
 			m = kBasicCanonicalJumpPoint;
+			ActivateModeButton(kBasicJPButton);
 			break;
 		case 'f':
 			submitTextToBuffer("Click/drag to show full canonical ordering");
 			m = kFullCanonical;
+			ActivateModeButton(kFullButton);
 			break;
 	}
 }
@@ -391,8 +542,12 @@ void GetPathHandler(tMouseEventType mType, point3d loc)
 	}
 }
 
-bool MyClickHandler(unsigned long , int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
+bool MyClickHandler(unsigned long , int viewport, int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
 {
+	// Prevent button clicks from affecting simulation.
+	if (viewport != 0)
+		return false;
+
 	int x, y;
 	me->GetMap()->GetPointFromCoordinate(loc, x, y);
 	xyLoc tmp(x, y);

--- a/demos/JPS/Driver.h
+++ b/demos/JPS/Driver.h
@@ -13,7 +13,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType);
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *data);
 void MyDisplayHandler(unsigned long windowID, tKeyboardModifier, char key);
 int MyCLHandler(char *argument[], int maxNumArgs);
-bool MyClickHandler(unsigned long windowID, int x, int y, point3d loc, tButtonType, tMouseEventType);
+bool MyClickHandler(unsigned long windowID, int viewport, int x, int y, point3d loc, tButtonType, tMouseEventType);
 void BuildGraphFromPuzzle(unsigned long windowID, tKeyboardModifier mod, char key);
 
 void InstallHandlers();

--- a/demos/STP/Driver.cpp
+++ b/demos/STP/Driver.cpp
@@ -48,6 +48,8 @@ PermutationPDB<MNPuzzleState<4, 4>, slideDir, MNPuzzle<4, 4>> *pdb2 = 0;
 PermutationPDB<MNPuzzleState<4, 4>, slideDir, MNPuzzle<4, 4>> *pdb3 = 0;
 PermutationPDB<MNPuzzleState<4, 4>, slideDir, MNPuzzle<4, 4>> *pdb4 = 0;
 
+void SetupGUI(int windowID);
+
 #ifndef __EMSCRIPTEN__
 void MakeAnimation();
 #endif
@@ -140,9 +142,21 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
 
 		ReinitViewports(windowID, {-1, -1, 1, 1}, kScaleToSquare);
+		SetupGUI(windowID);
 	}
 }
 
+void SetupGUI(int windowID)
+{
+	// Reset state
+	const float buttonHeight = 0.1f;
+	const float borderPaddingX = 0.2f;
+	const float borderPaddingY = 0.05f;
+	const float buttonWidth = 1.0f;
+	Graphics::roundedRect resetButton({1-borderPaddingX-buttonWidth, 1-buttonHeight-borderPaddingY, 1-borderPaddingX, 1-borderPaddingY}, 0.01f);
+	CreateButton(windowID, 0, resetButton, "Reset to random puzzle", 's', 0.01f, Colors::black, Colors::black,
+				Colors::white, Colors::lightblue, Colors::lightbluegray);
+}
 
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 {

--- a/demos/astar/Driver.cpp
+++ b/demos/astar/Driver.cpp
@@ -1,13 +1,13 @@
 /*
- *  $Id: sample.cpp
- *  hog2
- *
- *  Created by Nathan Sturtevant on 5/31/05.
- *  Modified by Nathan Sturtevant on 02/29/20.
- *
- * This file is part of HOG2. See https://github.com/nathansttt/hog2 for licensing information.
- *
- */
+*  $Id: sample.cpp
+*  hog2
+*
+*  Created by Nathan Sturtevant on 5/31/05.
+*  Modified by Nathan Sturtevant on 02/29/20.
+*
+* This file is part of HOG2. See https://github.com/nathansttt/hog2 for licensing information.
+*
+*/
 
 #include "Common.h"
 #include "Driver.h"
@@ -39,7 +39,7 @@ GraphEnvironment *ge;
 graphState from=-1, to=-1;
 Graphics::point currLoc;
 
-TextOverlay te(35);
+TextOverlay te(30);
 
 void SaveGraph(const char *file);
 void LoadGraph(const char *file);
@@ -58,10 +58,28 @@ public:
 
 GraphDistHeuristic searchHeuristic;
 
+std::vector<int> buttons;
+typedef enum : int {
+	kClearGraphButton = 0,
+	kLoadDefaultButton = 1,
+	kAddNodesButton = 2,
+	kAddEdgesButton = 3,
+	kMoveNodesButton = 4,
+	kDijkstraButton = 5,
+	kAStarButton = 6,
+	kWAStar2Button = 7,
+	kWAStar100Button = 8,
+	kFindPathButton = 9,
+	kStepSearchButton = 10,
+} buttonID;
+void ActivateModeButton(buttonID bId);
+void ActivateAlgButton(buttonID bId);
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
-	RunHOGGUI(argc, argv, 1600, 800);
+	RunHOGGUI(argc, argv, 1500, 1000);
 	return 0;
 }
 
@@ -114,7 +132,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		glClearColor(0.99, 0.99, 0.99, 1.0);
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
 		
-		SetNumPorts(windowID, 2);
+		SetNumPorts(windowID, 3);
 		g = new Graph();
 		ge = new GraphEnvironment(g);
 		ge->SetNodeScale(2.0);
@@ -127,9 +145,156 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		te.AddLine("Current mode: add nodes (click to add node)");
 		te.AddLine("Press [ or ] to change modes. '?' for help.");
 
-		ReinitViewports(windowID, {-1, -1, 0.0, 1}, kScaleToFill);
-		AddViewport(windowID, {0, -1, 1, 1}, kScaleToFill);
+		// Left half of screen
+		ReinitViewports(windowID, {-1, -1, 0.33f, 1}, kScaleToSquare);
+		// Split right half into two
+		AddViewport(windowID, {0.33f, -1, 1, 0}, kScaleToSquare);  // Buttons
+		AddViewport(windowID, {0.33f, 0, 1, 1}, kScaleToSquare);  // Text overlay
+		SetupGUI(windowID);
 	}
+}
+
+void DrawSim(Graphics::Display &display)
+{
+	if (ge == 0 || g == 0)
+		return;
+	display.FillRect({-1.0, -1.0, 1.0, 1}, Colors::white);
+	ge->SetColor(Colors::black);
+	ge->Draw(display);
+	
+	if (from != -1 && to != -1)
+	{
+		ge->SetColor(Colors::lightgray);
+		auto loc1 = ge->GetLocation(from);
+		ge->DrawLine(display, loc1.x, loc1.y, currLoc.x, currLoc.y, 2);
+	}
+	
+	ge->SetColor(Colors::white);
+	for (int x = 0; x < g->GetNumNodes(); x++)
+		ge->Draw(display, x);
+
+	if (running)
+	{
+		astar.Draw(display);
+	}
+	
+	if (path.size() > 0)
+	{
+		ge->SetColor(0, 1, 0);
+		for (size_t x = 1; x < path.size(); x++)
+		{
+			ge->DrawLine(display, path[x-1], path[x], 4);
+		}
+	}
+
+	return;
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 0.1f;
+	const float borderPaddingY = 0.35f;
+	const float verticalSep = 0.25f;
+	const float buttonHeight = 0.1f;
+
+	// General graph management
+	float horizontalSep = 0.3f;
+	float buttonWidth = 0.75f;
+	float top = -1+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect graphButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 1, graphButton, "Clear Graph", '|', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	graphButton.r += offsetRect;
+	b = CreateButton(windowID, 1, graphButton, "Load Default", 'd', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Modifying the graph
+	horizontalSep = 0.15f;
+	buttonWidth = 0.5f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect modeButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, modeButton, "Add Nodes", 'n', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	modeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, modeButton, "Add Edges", 'e', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	modeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, modeButton, "Move Nodes", 'm', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Search algorithms
+	horizontalSep = 0.1f;
+	buttonWidth = 0.375f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect algButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, algButton, "Dijkstra", '1', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 1, algButton, "A*", '2', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 1, algButton, "WA*(2)", '3', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	algButton.r += offsetRect;
+	b = CreateButton(windowID, 1, algButton, "WA*(100)", '4', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Simulating search
+	horizontalSep = 0.3f;
+	buttonWidth = 0.75f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect simulationButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, simulationButton, "Find Path", 'a', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	simulationButton.r += offsetRect;
+	b = CreateButton(windowID, 1, simulationButton, "Step Search", 'o', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-1, -1, 1, 1}, Colors::darkgray);
+	display.FillRect({-1+e, -1+e, 1-e, 1-e}, Colors::lightgray);
+	display.DrawText("Graph: ", {-1+0.1f, -0.8f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Mode: ", {-1+0.1f, -0.45f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Algorithm: ", {-1+0.1f, -0.10f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Simulation: ", {-1+0.1f, 0.25f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void ActivateModeButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kAddNodesButton], bId == kAddNodesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kAddEdgesButton], bId == kAddEdgesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kMoveNodesButton], bId == kMoveNodesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kFindPathButton], bId == kFindPathButton ? Colors::yellow : Colors::white);
+}
+
+void ActivateAlgButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kDijkstraButton], bId == kDijkstraButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kAStarButton], bId == kAStarButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kWAStar2Button], bId == kWAStar2Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kWAStar100Button], bId == kWAStar100Button ? Colors::yellow : Colors::white);
 }
 
 int frameCnt = 0;
@@ -137,43 +302,13 @@ int frameCnt = 0;
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 {
 	Graphics::Display &display = getCurrentContext()->display;
-	if (viewport == 0)
-	{
-		if (ge == 0 || g == 0)
-			return;
-		display.FillRect({-1.0, -1.0, 1.0, 1}, Colors::white);
-		ge->SetColor(Colors::black);
-		ge->Draw(display);
-		
-		if (from != -1 && to != -1)
-		{
-			ge->SetColor(Colors::lightgray);
-			auto loc1 = ge->GetLocation(from);
-			ge->DrawLine(display, loc1.x, loc1.y, currLoc.x, currLoc.y, 2);
-		}
-		
-		ge->SetColor(Colors::white);
-		for (int x = 0; x < g->GetNumNodes(); x++)
-			ge->Draw(display, x);
 
-		if (running)
-		{
-			astar.Draw(display);
-		}
-		
-		if (path.size() > 0)
-		{
-			ge->SetColor(0, 1, 0);
-			for (size_t x = 1; x < path.size(); x++)
-			{
-				ge->DrawLine(display, path[x-1], path[x], 4);
-			}
-		}
-	}
-	if (viewport == 1)
-	{
+	if (viewport == 0)
+		DrawSim(display);
+	else if (viewport == 1)
+		DrawGUI(display);
+	else
 		te.Draw(display);
-	}
 	
 //	if (recording && viewport == GetNumPorts(windowID)-1)
 //	{
@@ -191,8 +326,6 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 //			recording = false;
 //		}
 //	}
-	return;
-	
 }
 
 int MyCLHandler(char *argument[], int maxNumArgs)
@@ -207,16 +340,13 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 {
 	switch (key)
 	{
-		case 'a':
-			m = kFindPath; te.AddLine("Current mode: find path"); break;
-		case 'n':
-			m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
-		case 'e':
-			m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-		case 'm':
-			m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
+		case 'a': m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
+		case 'n': m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
+		case 'e': m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+		case 'm': m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
 		case '1': // Dijkstra
 			te.AddLine("Algorithm: Dijkstra");
+			ActivateAlgButton(kDijkstraButton);
 			weight = 0.0;
 			astar.SetWeight(weight);
 			if (running)
@@ -225,11 +355,12 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				ShowSearchInfo();
 			}
 			else {
-				m = kFindPath; te.AddLine("Current mode: find path"); break;
+				m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 			}
 			break;
 		case '2': // A*
 			te.AddLine("Algorithm: A*");
+			ActivateAlgButton(kAStarButton);
 			weight = 1.0;
 			astar.SetWeight(weight);
 			if (running)
@@ -238,11 +369,12 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				ShowSearchInfo();
 			}
 			else {
-				m = kFindPath; te.AddLine("Current mode: find path"); break;
+				m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 			}
 			break;
 		case '3': // WA*(2)
 			te.AddLine("Algorithm: WA*(2)");
+			ActivateAlgButton(kWAStar2Button);
 			weight = 2.0;
 			astar.SetWeight(weight);
 			if (running)
@@ -251,11 +383,12 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				ShowSearchInfo();
 			}
 			else {
-				m = kFindPath; te.AddLine("Current mode: find path"); break;
+				m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 			}
 			break;
 		case '4': // WA*(100)
 			te.AddLine("Algorithm: WA*(100)");
+			ActivateAlgButton(kWAStar100Button);
 			weight = 100.0;
 			astar.SetWeight(weight);
 			if (running)
@@ -264,7 +397,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				ShowSearchInfo();
 			}
 			else {
-				m = kFindPath; te.AddLine("Current mode: find path"); break;
+				m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 			}
 			break;
 
@@ -272,10 +405,10 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 		{
 			switch (m)
 			{
-				case kAddNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-				case kAddEdges: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
-				case kMoveNodes: m = kFindPath; te.AddLine("Current mode: find path"); break;
-				case kFindPath: m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
+				case kAddNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+				case kAddEdges: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
+				case kMoveNodes: m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
+				case kFindPath: m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
 			}
 
 		}
@@ -284,10 +417,10 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 		{
 			switch (m)
 			{
-				case kMoveNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-				case kFindPath: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
-				case kAddNodes: m = kFindPath; te.AddLine("Current mode: find path"); break;
-				case kAddEdges: m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
+				case kMoveNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+				case kFindPath: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
+				case kAddNodes: m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
+				case kAddEdges: m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
 			}
 		}
 			break;
@@ -296,6 +429,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			name[0] = 'a';
 			g->Reset();
 			te.AddLine("Current mode: add nodes");
+			ActivateModeButton(kAddNodesButton);
 			m = kAddNodes;
 			path.resize(0);
 			running = false;
@@ -318,7 +452,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				ShowSearchInfo();
 			}
 			else {
-				m = kFindPath; te.AddLine("Current mode: find path"); break;
+				m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 			}
 
 			break;
@@ -609,8 +743,12 @@ node *FindClosestNode(Graph *gr, point3d loc)
 }
 
 
-bool MyClickHandler(unsigned long , int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
+bool MyClickHandler(unsigned long , int viewport, int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
 {
+	// Prevent button clicks from drawing on the graph.
+	if (viewport != 0)
+		return false;
+
 	if (mType == kMouseDown)
 	{
 		switch (button)

--- a/demos/astar/Driver.h
+++ b/demos/astar/Driver.h
@@ -13,7 +13,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType);
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *data);
 void MyDisplayHandler(unsigned long windowID, tKeyboardModifier, char key);
 int MyCLHandler(char *argument[], int maxNumArgs);
-bool MyClickHandler(unsigned long windowID, int x, int y, point3d loc, tButtonType, tMouseEventType);
+bool MyClickHandler(unsigned long windowID, int viewport, int x, int y, point3d loc, tButtonType, tMouseEventType);
 void BuildGraphFromPuzzle(unsigned long windowID, tKeyboardModifier mod, char key);
 
 void InstallHandlers();

--- a/demos/dh-place/Driver.cpp
+++ b/demos/dh-place/Driver.cpp
@@ -81,10 +81,24 @@ public:
 
 DifferentialHeuristic searchHeuristic;
 
+std::vector<int> buttons;
+typedef enum : int {
+	kPlaceDHButton = 0,
+	kClearDHButton = 1,
+	kGradientButton = 2,
+	kFindPathButton = 3,
+	kSlowerButton = 4,
+	kFasterButton = 5,
+	kLowHeuristicButton = 6,
+	kHighHeuristicButton = 7,
+} buttonID;
+void ActivateModeButton(buttonID bId);
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
-	RunHOGGUI(argc, argv, 1200, 1200);
+	RunHOGGUI(argc, argv, 1600, 1200);
 	return 0;
 }
 
@@ -122,7 +136,12 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		printf("Window %ld created\n", windowID);
 		//glClearColor(0.99, 0.99, 0.99, 1.0);
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
-		SetNumPorts(windowID, 1);
+		SetNumPorts(windowID, 2);
+		// Left part of screen
+		ReinitViewports(windowID, {-1, -1, 0.5f, 1}, kScaleToSquare);
+		// Right part of screen (buttons)
+		AddViewport(windowID, {0.5f, -1, 1, 1}, kScaleToSquare);
+		SetupGUI(windowID);
 		
 		Map *map = new Map(1,1);
 		LoadMap(map);
@@ -138,10 +157,8 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 
 int frameCnt = 0;
 
-void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+void DrawSim(Graphics::Display &display)
 {
-	Graphics::Display &display = getCurrentContext()->display;
-	
 	if (mapChange == true)
 	{
 		display.StartBackground();
@@ -223,6 +240,104 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 			}
 		}
 	}
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 0.1f;
+	const float borderPaddingY = 0.35f;
+	const float verticalSep = 0.25f;
+	const float buttonHeight = 0.1f;
+
+	// Differential heuristic controls
+	float horizontalSep = 0.3f;
+	float buttonWidth = 0.75f;
+	float top = -1+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect dhButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 1, dhButton, "Place DH", 'a', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	dhButton.r += offsetRect;
+	b = CreateButton(windowID, 1, dhButton, "Clear DH", '|', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	buttonWidth = 1.2f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect drawButton({-1+0.4f, top, -1+0.4f+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, drawButton, "Toggle Drawing Gradient", 'd', 0.01f, Colors::black, Colors::black,
+		Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Simulation controls
+	horizontalSep = 0.15f;
+	buttonWidth = 0.6f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect pathButton({-1+0.7f, top, -1+0.7f+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, pathButton, "Find Path", 'p', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	horizontalSep = 0.2f;
+	buttonWidth = 0.8f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect speedButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, speedButton, "Simulate Slower", '[', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	speedButton.r += offsetRect;
+	b = CreateButton(windowID, 1, speedButton, "Simulate Faster", ']', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Minigame
+	horizontalSep = 0.2f;
+	buttonWidth = 0.6f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect testButton({-1+0.3f, top, -1+0.3f+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, testButton, "Low", 'l', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	testButton.r += offsetRect;
+	b = CreateButton(windowID, 1, testButton, "High", 'h', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-1, -2.45f, 1, 2.45f}, Colors::darkgray);
+	display.FillRect({-1+e, -2.45f+e, 1-e, 2.45f-e}, Colors::lightgray);
+	display.DrawText("DH: ", {-1+0.1f, -0.8f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Path: ", {-1+0.1f, -0.25f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Find Heuristics: ", {-1+0.1f, 0.3f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void ActivateModeButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kPlaceDHButton], bId == kPlaceDHButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kFindPathButton], bId == kFindPathButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kLowHeuristicButton], bId == kLowHeuristicButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kHighHeuristicButton], bId == kHighHeuristicButton ? Colors::yellow : Colors::white);
+}
+
+void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+{
+	Graphics::Display &display = getCurrentContext()->display;
+	
+	if (viewport == 0)
+		DrawSim(display);
+	else
+		DrawGUI(display);
 
 //	if (viewport == 0)
 //	{
@@ -262,7 +377,6 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 //		}
 //	}
 //	return;
-	
 }
 
 int MyCLHandler(char *argument[], int maxNumArgs)
@@ -299,6 +413,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case 'a':
 			submitTextToBuffer("Click anywhere in the map to place a differential heuristic");
+			ActivateModeButton(kPlaceDHButton);
 			m = kAddDH;
 			break;
 		case 'm':
@@ -311,6 +426,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			break;
 		case 'd':
 			showDH = !showDH;
+			SetButtonFillColor(buttons[kGradientButton], showDH ? Colors::yellow : Colors::white);
 			mapChange = true;
 			break;
 		case 'p':
@@ -320,6 +436,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				showDH = false;
 				mapChange = true;
 			}
+			ActivateModeButton(kFindPathButton);
 			m = kFindPath;
 			start = goal = {0, 0};
 			path.resize(0);
@@ -333,6 +450,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				break;
 			}
 			submitTextToBuffer("Select two of the points that have a high heuristic value in the current DH");
+			ActivateModeButton(kHighHeuristicButton);
 			m = kIdentifyHighHeuristic;
 			FindSamplePoints();
 			break;
@@ -343,6 +461,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 				break;
 			}
 			submitTextToBuffer("Select two of the points that have a low heuristic value in the current DH");
+			ActivateModeButton(kLowHeuristicButton);
 			m = kIdentifyLowHeuristic;
 			FindSamplePoints();
 			break;
@@ -505,8 +624,12 @@ void GetMeasureHandler(tMouseEventType mType, point3d loc)
 	submitTextToBuffer(ss.str().c_str());
 }
 
-bool MyClickHandler(unsigned long , int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
+bool MyClickHandler(unsigned long , int viewport, int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
 {
+	// Prevent button clicks from affecting simulation.
+	if (viewport != 0)
+		return false;
+
 	switch (m)
 	{
 		case kAddDH: DHMouseHandler(mType, loc); break;

--- a/demos/dh-place/Driver.h
+++ b/demos/dh-place/Driver.h
@@ -13,7 +13,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType);
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *data);
 void MyDisplayHandler(unsigned long windowID, tKeyboardModifier, char key);
 int MyCLHandler(char *argument[], int maxNumArgs);
-bool MyClickHandler(unsigned long windowID, int x, int y, point3d loc, tButtonType, tMouseEventType);
+bool MyClickHandler(unsigned long windowID, int viewport, int x, int y, point3d loc, tButtonType, tMouseEventType);
 void BuildGraphFromPuzzle(unsigned long windowID, tKeyboardModifier mod, char key);
 
 void InstallHandlers();

--- a/demos/dijkstra/Driver.cpp
+++ b/demos/dijkstra/Driver.cpp
@@ -38,15 +38,38 @@ GraphEnvironment *ge;
 graphState from=-1, to=-1;
 Graphics::point currLoc;
 
-TextOverlay te(35);
+TextOverlay te(30);
 
 void ShowSearchInfo();
 static char name[2] = "a";
 
+std::vector<int> buttons;
+typedef enum : int {
+	kLoadGraphButton = 0,
+	kClearGraphButton = 1,
+	kAddNodesButton = 2,
+	kAddEdgesButton = 3,
+	kMoveNodesButton = 4,
+	kFindPathButton = 5,
+	kEdgeCost1Button = 6,
+	kEdgeCost2Button = 7,
+	kEdgeCost3Button = 8,
+	kEdgeCost4Button = 9,
+	kEdgeCost5Button = 10,
+	kEdgeCost6Button = 11,
+	kEdgeCost7Button = 12,
+	kEdgeCost8Button = 13,
+	kEdgeCost9Button = 14,
+	kStepSearchButton = 15,
+} buttonID;
+void ActivateModeButton(buttonID bId);
+void ActivateEdgeCostButton(buttonID bId);
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
-	RunHOGGUI(argc, argv, 1600, 800);
+	RunHOGGUI(argc, argv, 1500, 1000);
 	return 0;
 }
 
@@ -91,11 +114,15 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 	{
 		printf("Window %ld created\n", windowID);
 		//glClearColor(0.99, 0.99, 0.99, 1.0);
-		ReinitViewports(windowID, {-1, -1, 0.0, 1}, kScaleToFill);
-		AddViewport(windowID, {0, -1, 1, 1}, kScaleToFill);
 //		ReinitViewports(windowID, {-1, -1, 1, 0}, kScaleToFill);
 //		AddViewport(windowID, {-1, 0, 1, 1}, kScaleToFill);
 
+		// Left part of screen
+		ReinitViewports(windowID, {-1, -1, 0.33f, 1}, kScaleToSquare);
+		// Split right part into two
+		AddViewport(windowID, {0.33f, -1, 1, 0}, kScaleToSquare);  // Buttons
+		AddViewport(windowID, {0.33f, 0, 1, 1}, kScaleToSquare);  // Text overlay
+		SetupGUI(windowID);
 		
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
 //		SetNumPorts(windowID, 2);
@@ -114,49 +141,186 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 
 int frameCnt = 0;
 
+void DrawSim(Graphics::Display &display)
+{
+	display.FillRect({-1.0, -1.0, 1.0, 1}, Colors::white);
+	if (ge == 0 || g == 0)
+		return;
+	// Draw edges, costs/labels
+	ge->SetColor(Colors::gray);
+	ge->Draw(display);
+	if (from != -1 && to != -1)
+	{
+		ge->SetColor(0.5, 0, 0);
+		auto loc1 = ge->GetLocation(from);
+		ge->DrawLine(display, loc1.x, loc1.y, currLoc.x, currLoc.y, 2);
+	}
+	
+	// Draw nodes
+	ge->SetColor(Colors::white);
+	for (int x = 0; x < g->GetNumNodes(); x++)
+		ge->Draw(display, x);
+	
+	// Draw search state
+	if (running)
+	{
+		astar.Draw(display);
+	}
+
+	// Draw path
+	if (path.size() > 0)
+	{
+		ge->SetColor(0, 0.5, 0);
+		for (size_t x = 1; x < path.size(); x++)
+		{
+			ge->DrawLine(display, path[x-1], path[x], 6);
+		}
+	}
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 0.1f;
+	const float borderPaddingY = 0.35f;
+	const float verticalSep = 0.25f;
+	const float buttonHeight = 0.1f;
+
+	// General graph management
+	float horizontalSep = 0.3f;
+	float buttonWidth = 0.75f;
+	float top = -1+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect graphButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 1, graphButton, "Load Graph", 'a', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	graphButton.r += offsetRect;
+	b = CreateButton(windowID, 1, graphButton, "Clear Graph", '|', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Mode for modifying graph
+	horizontalSep = 0.15f;
+	buttonWidth = 0.5f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect modeButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, modeButton, "Add Nodes", 'n', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	modeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, modeButton, "Add Edges", 'e', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	modeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, modeButton, "Move Nodes", 'm', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Finding path
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect pathButton({-1+0.75f, top, -1+0.75f+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, pathButton, "Find Path", 'f', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Edge cost
+	horizontalSep = 0.06f;
+	buttonWidth = 0.15f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect edgeButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, edgeButton, "1", '1', 0.01f, Colors::black, Colors::black,
+					Colors::yellow, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "2", '2', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "3", '3', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "4", '4', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "5", '5', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "6", '6', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "7", '7', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "8", '8', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	edgeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, edgeButton, "9", '9', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Simulating search
+	buttonWidth = 0.75f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect simulationButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, simulationButton, "Step Search", 'o', 0.01f, Colors::black, Colors::black,
+					Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-1, -1, 1, 1}, Colors::darkgray);
+	display.FillRect({-1+e, -1+e, 1-e, 1-e}, Colors::lightgray);
+	display.DrawText("Graph: ", {-1+0.1f, -0.8f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Mode: ", {-1+0.1f, -0.45f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Edge Cost: ", {-1+0.1f, 0.1f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Search: ", {-1+0.1f, 0.45f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void ActivateModeButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kAddNodesButton], bId == kAddNodesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kAddEdgesButton], bId == kAddEdgesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kMoveNodesButton], bId == kMoveNodesButton ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kFindPathButton], bId == kFindPathButton ? Colors::yellow : Colors::white);
+}
+
+void ActivateEdgeCostButton(buttonID bId)
+{
+	SetButtonFillColor(buttons[kEdgeCost1Button], bId == kEdgeCost1Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost2Button], bId == kEdgeCost2Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost3Button], bId == kEdgeCost3Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost4Button], bId == kEdgeCost4Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost5Button], bId == kEdgeCost5Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost6Button], bId == kEdgeCost6Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost7Button], bId == kEdgeCost7Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost8Button], bId == kEdgeCost8Button ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kEdgeCost9Button], bId == kEdgeCost9Button ? Colors::yellow : Colors::white);
+}
+
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 {
 	Graphics::Display &display = getCurrentContext()->display;
 	if (viewport == 0)
-	{
-		display.FillRect({-1.0, -1.0, 1.0, 1}, Colors::white);
-		if (ge == 0 || g == 0)
-			return;
-		// Draw edges, costs/labels
-		ge->SetColor(Colors::gray);
-		ge->Draw(display);
-		if (from != -1 && to != -1)
-		{
-			ge->SetColor(0.5, 0, 0);
-			auto loc1 = ge->GetLocation(from);
-			ge->DrawLine(display, loc1.x, loc1.y, currLoc.x, currLoc.y, 2);
-		}
-		
-		// Draw nodes
-		ge->SetColor(Colors::white);
-		for (int x = 0; x < g->GetNumNodes(); x++)
-			ge->Draw(display, x);
-		
-		// Draw search state
-		if (running)
-		{
-			astar.Draw(display);
-		}
-
-		// Draw path
-		if (path.size() > 0)
-		{
-			ge->SetColor(0, 0.5, 0);
-			for (size_t x = 1; x < path.size(); x++)
-			{
-				ge->DrawLine(display, path[x-1], path[x], 6);
-			}
-		}
-	}
-	if (viewport == 1)
-	{
+		DrawSim(display);
+	else if (viewport == 1)
+		DrawGUI(display);
+	else
 		te.Draw(display);
-	}
 	
 	if (recording && viewport == GetNumPorts(windowID)-1)
 	{
@@ -190,18 +354,18 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 {
 	switch (key)
 	{
-		case 'n': m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
-		case 'e': m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-		case 'm': m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
-		case 'f': m = kFindPath; te.AddLine("Current mode: find path"); break;
+		case 'n': m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
+		case 'e': m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+		case 'm': m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
+		case 'f': m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
 		case ']':
 		{
 			switch (m)
 			{
-				case kAddNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-				case kAddEdges: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
-				case kMoveNodes: m = kFindPath; te.AddLine("Current mode: find path"); break;
-				case kFindPath: m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
+				case kAddNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+				case kAddEdges: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
+				case kMoveNodes: m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
+				case kFindPath: m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
 			}
 
 		}
@@ -210,10 +374,10 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 		{
 			switch (m)
 			{
-				case kMoveNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); break;
-				case kFindPath: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); break;
-				case kAddNodes: m = kFindPath; te.AddLine("Current mode: find path"); break;
-				case kAddEdges: m = kAddNodes; te.AddLine("Current mode: add nodes"); break;
+				case kMoveNodes: m = kAddEdges; te.AddLine("Current mode: add edges"); ActivateModeButton(kAddEdgesButton); break;
+				case kFindPath: m = kMoveNodes; te.AddLine("Current mode: moves nodes"); ActivateModeButton(kMoveNodesButton); break;
+				case kAddNodes: m = kFindPath; te.AddLine("Current mode: find path"); ActivateModeButton(kFindPathButton); break;
+				case kAddEdges: m = kAddNodes; te.AddLine("Current mode: add nodes"); ActivateModeButton(kAddNodesButton); break;
 			}
 		}
 			break;
@@ -222,6 +386,7 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			name[0] = 'a';
 			g->Reset();
 			te.AddLine("Current mode: add nodes");
+			ActivateModeButton(kAddNodesButton);
 			m = kAddNodes;
 			path.resize(0);
 			running = false;
@@ -231,15 +396,15 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key)
 			recording = !recording;
 			break;
 		case '0':
-		case '1': edgeCost = 1.0; te.AddLine("Adding edges; New edges cost 1"); m = kAddEdges; break;
-		case '2': edgeCost = 2.0; te.AddLine("Adding edges; New edges cost 2"); m = kAddEdges; break;
-		case '3': edgeCost = 3.0; te.AddLine("Adding edges; New edges cost 3"); m = kAddEdges; break;
-		case '4': edgeCost = 4.0; te.AddLine("Adding edges; New edges cost 4"); m = kAddEdges; break;
-		case '5': edgeCost = 5.0; te.AddLine("Adding edges; New edges cost 5"); m = kAddEdges; break;
-		case '6': edgeCost = 6.0; te.AddLine("Adding edges; New edges cost 6"); m = kAddEdges; break;
-		case '7': edgeCost = 7.0; te.AddLine("Adding edges; New edges cost 7"); m = kAddEdges; break;
-		case '8': edgeCost = 8.0; te.AddLine("Adding edges; New edges cost 8"); m = kAddEdges; break;
-		case '9': edgeCost = 9.0; te.AddLine("Adding edges; New edges cost 9"); m = kAddEdges; break;
+		case '1': edgeCost = 1.0; te.AddLine("Adding edges; New edges cost 1"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost1Button); ActivateModeButton(kAddEdgesButton); break;
+		case '2': edgeCost = 2.0; te.AddLine("Adding edges; New edges cost 2"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost2Button); ActivateModeButton(kAddEdgesButton); break;
+		case '3': edgeCost = 3.0; te.AddLine("Adding edges; New edges cost 3"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost3Button); ActivateModeButton(kAddEdgesButton); break;
+		case '4': edgeCost = 4.0; te.AddLine("Adding edges; New edges cost 4"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost4Button); ActivateModeButton(kAddEdgesButton); break;
+		case '5': edgeCost = 5.0; te.AddLine("Adding edges; New edges cost 5"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost5Button); ActivateModeButton(kAddEdgesButton); break;
+		case '6': edgeCost = 6.0; te.AddLine("Adding edges; New edges cost 6"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost6Button); ActivateModeButton(kAddEdgesButton); break;
+		case '7': edgeCost = 7.0; te.AddLine("Adding edges; New edges cost 7"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost7Button); ActivateModeButton(kAddEdgesButton); break;
+		case '8': edgeCost = 8.0; te.AddLine("Adding edges; New edges cost 8"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost8Button); ActivateModeButton(kAddEdgesButton); break;
+		case '9': edgeCost = 9.0; te.AddLine("Adding edges; New edges cost 9"); m = kAddEdges; ActivateEdgeCostButton(kEdgeCost9Button); ActivateModeButton(kAddEdgesButton); break;
 		case '\t':
 			break;
 		case 'p':

--- a/demos/pancake/Driver.cpp
+++ b/demos/pancake/Driver.cpp
@@ -37,6 +37,8 @@ std::vector<PancakePuzzleAction> acts;
 //std::vector<PancakePuzzleState<16>> path;
 PancakePuzzleAction drawAction = 0;
 
+void SetupGUI(int windowID);
+
 int main(int argc, char* argv[])
 {
 	InstallHandlers();
@@ -73,9 +75,26 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
 
 		ReinitViewports(windowID, {-1, -1, 1, 1}, kScaleToFill);
+		SetupGUI(windowID);
 	}
 }
 
+void SetupGUI(int windowID)
+{
+	// Basic controls
+	const float buttonHeight = 0.1f;
+	const float borderPaddingX = 0.15f;
+	const float borderPaddingY = 0.1f;
+	const float buttonWidth = 0.8f;
+	const float horizontalSep = 0.1f;
+	Graphics::roundedRect puzzleButton({-1+borderPaddingX, 1-buttonHeight-borderPaddingY, -1+borderPaddingX+buttonWidth, 1-borderPaddingY}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	CreateButton(windowID, 0, puzzleButton, "Randomize Puzzle", 's', 0.01f, Colors::black, Colors::black,
+				Colors::white, Colors::lightblue, Colors::lightbluegray);
+				puzzleButton.r += offsetRect;
+	CreateButton(windowID, 0, puzzleButton, "Solve Puzzle", 'o', 0.01f, Colors::black, Colors::black,
+				Colors::white, Colors::lightblue, Colors::lightbluegray);
+}
 
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 {

--- a/demos/racetrack/Driver.cpp
+++ b/demos/racetrack/Driver.cpp
@@ -34,6 +34,22 @@ std::vector<RacetrackState> bestPath;
 std::vector<RacetrackState> legalSuccessors;
 bool mapUpdated = true;
 TemplateAStar<RacetrackState, RacetrackMove, Racetrack> astar;
+
+std::vector<int> buttons;
+typedef enum : int {
+	kResetButton = 0,
+	kOptimalButton = 1,
+	kRandomButton = 2,
+	kLargeRoomsButton = 3,
+	kMediumRoomsButton = 4,
+	kSmallRoomsButton = 5,
+	kLargeMazeButton = 6,
+	kMediumMazeButton = 7,
+	kSmallMazeButton = 8,
+} buttonID;
+void ActivateMapButton(int mapType);
+void SetupGUI(int windowID);
+
 // -------------- MAIN FUNCTION ----------- //
 int main(int argc, char* argv[])
 {
@@ -78,6 +94,7 @@ void MakeMap(int mapType = -1)
 	{
 		which = random()%7;
 	}
+	ActivateMapButton(6-which);
 	switch (which)
 	{
 		case 0:
@@ -140,7 +157,12 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 	{
 		printf("Window %ld created\n", windowID);
 		InstallFrameHandler(MyFrameHandler, windowID, 0);
-		ReinitViewports(windowID, {-1, -1, 1, 1}, kScaleToSquare);
+
+		// Left half of screen
+		ReinitViewports(windowID, {-1, -1, 0, 1}, kScaleToSquare);
+		// Right half of screen (buttons)
+		AddViewport(windowID, {0, -1, 1, 1}, kScaleToSquare);
+		SetupGUI(windowID);
 
 		srandom((unsigned int)time(0));
 		MakeMap();
@@ -155,11 +177,8 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType)
 	}
 }
 
-
-void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+void DrawSim(Graphics::Display &display)
 {
-	Graphics::Display &display = getCurrentContext()->display;
-
 	if (mapUpdated)
 	{
 		mapUpdated = false;
@@ -250,6 +269,106 @@ void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
 		display.DrawText("You Crashed!", {0, 0}, Colors::purple, 0.15f, Graphics::textAlignCenter, Graphics::textBaselineMiddle);
 		display.DrawText("Reset to try again", {0.0f, 0.1f}, Colors::darkred, 0.04f, Graphics::textAlignCenter, Graphics::textBaselineBottom);
 	}
+}
+
+void SetupGUI(int windowID)
+{
+	const float borderPaddingX = 0.1f;
+	const float borderPaddingY = 0.35f;
+	const float verticalSep = 0.25f;
+	const float buttonHeight = 0.1f;
+
+	// Basic controls
+	float horizontalSep = 0.1f;
+	float buttonWidth = 0.8f;
+	float top = -1+borderPaddingY;
+	float bot = top+buttonHeight;
+	Graphics::roundedRect problemButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	Graphics::rect offsetRect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	int b = CreateButton(windowID, 1, problemButton, "Reset Problem", 'r', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	problemButton.r += offsetRect;
+	b = CreateButton(windowID, 1, problemButton, "Optimal Solution", 'o', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Random map
+	buttonWidth = 0.55f;
+	top = bot+verticalSep;
+	bot = top+buttonHeight;
+	Graphics::roundedRect randomButton({-1+0.725f, top, -1+0.725f+buttonWidth, bot}, 0.01f);
+	b = CreateButton(windowID, 1, randomButton, "Random", 'm', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+
+	// Rooms map
+	horizontalSep = 0.075f;
+	buttonWidth = 0.55f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect roomButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, roomButton, "Large Rooms", '0', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	roomButton.r += offsetRect;
+	b = CreateButton(windowID, 1, roomButton, "Medium Rooms", '1', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	roomButton.r += offsetRect;
+	b = CreateButton(windowID, 1, roomButton, "Small Rooms", '2', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	roomButton.r += offsetRect;
+
+	// Maze map
+	horizontalSep = 0.075f;
+	buttonWidth = 0.55f;
+	top = bot+0.1f;
+	bot = top+buttonHeight;
+	Graphics::roundedRect mazeButton({-1+borderPaddingX, top, -1+borderPaddingX+buttonWidth, bot}, 0.01f);
+	offsetRect = Graphics::rect(buttonWidth+horizontalSep, 0, buttonWidth+horizontalSep, 0);
+	b = CreateButton(windowID, 1, mazeButton, "Large Maze", '4', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	mazeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, mazeButton, "Medium Maze", '5', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+	mazeButton.r += offsetRect;
+	b = CreateButton(windowID, 1, mazeButton, "Small Maze", '6', 0.01f, Colors::black, Colors::black,
+					 Colors::white, Colors::lightblue, Colors::lightbluegray);
+	buttons.push_back(b);
+}
+
+void ActivateMapButton(int mapType)
+{
+	SetButtonFillColor(buttons[kLargeRoomsButton], mapType == 0 ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kMediumRoomsButton], mapType == 1 ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kSmallRoomsButton], mapType == 2 ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kLargeMazeButton], mapType == 4 ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kMediumMazeButton], mapType == 5 ? Colors::yellow : Colors::white);
+	SetButtonFillColor(buttons[kSmallMazeButton], mapType == 6 ? Colors::yellow : Colors::white);
+}
+
+void DrawGUI(Graphics::Display &display)
+{
+	const float e = 0.03f;
+	display.FillRect({-1, -1, 1, 1}, Colors::darkgray);
+	display.FillRect({-1+e, -1+e, 1-e, 1-e}, Colors::lightgray);
+	display.DrawText("Control: ", {-1+0.1f, -0.8f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+	display.DrawText("Map: ", {-1+0.1f, -0.45f}, Colors::black, 0.1f, Graphics::textAlignLeft, Graphics::textBaselineTop);
+}
+
+void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *)
+{
+	Graphics::Display &display = getCurrentContext()->display;
+
+	if (viewport == 0)
+		DrawSim(display);
+	else
+		DrawGUI(display);
 }
 
 int MyCLHandler(char *argument[], int maxNumArgs)
@@ -414,8 +533,12 @@ void MyDisplayHandler(unsigned long windowID, tKeyboardModifier mod, char key) /
  *
  * Application does not currently need mouse support
  */
-bool MyClickHandler(unsigned long , int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
+bool MyClickHandler(unsigned long , int viewport, int windowX, int windowY, point3d loc, tButtonType button, tMouseEventType mType)
 {
+	// Prevent button clicks from affecting simulation.
+	if (viewport != 0)
+		return false;
+
 	int x, y;
 	m->GetPointFromCoordinate(loc, x, y);
 

--- a/demos/racetrack/Driver.h
+++ b/demos/racetrack/Driver.h
@@ -13,7 +13,7 @@ void MyWindowHandler(unsigned long windowID, tWindowEventType eType);
 void MyFrameHandler(unsigned long windowID, unsigned int viewport, void *data);
 void MyDisplayHandler(unsigned long windowID, tKeyboardModifier, char key);
 int MyCLHandler(char *argument[], int maxNumArgs);
-bool MyClickHandler(unsigned long windowID, int x, int y, point3d loc, tButtonType, tMouseEventType);
+bool MyClickHandler(unsigned long windowID, int viewport, int x, int y, point3d loc, tButtonType, tMouseEventType);
 void BuildGraphFromPuzzle(unsigned long windowID, tKeyboardModifier mod, char key);
 
 void InstallHandlers();


### PR DESCRIPTION
Adds buttons to the listed demos, following the example from the astar-map demo:
- astar
- STP
- pancake
- racetrack
- DFID
- dijkstra
- dh-place
- JPS

Button functionality follows the website demos, although one notable improvement is that state tracking (e.g. which algorithm is currently selected) is present through button highlighting.

Also adds Makefiles for building a few missing demos with SFML.